### PR TITLE
Port PyPop to Numpy

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -8,17 +8,6 @@
 * ```libxml2/libxslt``` (Python bindings)
 * ```pytest``` (Python test framework)
 
-## Installing ```python-numeric``` on recent Ubuntu releases
-
-```python-numeric``` is not available in recent Ubuntu releases, for the time being you can temporarily add the distribution, ```natty``` with the last working version of python-numeric to your list of repositories.  To do this edit ```/etc/apt/sources.list``` and the following lines:
- 
-    deb http://old-releases.ubuntu.com/ubuntu natty main restricted universe multiverse 
-
-then run:
-
-     sudo apt update
-     sudo apt install python-numeric
-
 ## Installing ```swig``` on recent Ubuntu releases
 
 There is a bug in versions swig 3.0.6 to 3.0.10 that prevents swig on ```xenial``` (which is version 3.0.8 of swig) working.  You will need to install the lastest version from source.

--- a/PyPop/DataTypes.py
+++ b/PyPop/DataTypes.py
@@ -123,6 +123,11 @@ class Genotypes:
     def _checkAllele(self, allele1, allele2, unsequencedSites):
         for phase in [allele1, allele2]:
             if (self.untypedAllele != phase and self.unsequencedSite != phase):
+                if self.debug:
+                    print "alleleTable:", self.alleleTable
+                    print "alleleTable type:", type(self.alleleTable)
+                    print "phase:", phase
+                    print "phase type:", type(phase)
                 if self.alleleTable.has_key(phase):
                     self.alleleTable[phase] += 1
                 else:
@@ -182,7 +187,7 @@ class Genotypes:
                 if self.debug:
                     print rowCount, subMatrix[line],
 
-                allele1, allele2 = subMatrix[line]
+                allele1, allele2 = [str(i) for i in subMatrix[line]]
 
                 if self.debug:
                     print allele1, allele2

--- a/PyPop/Utils.py
+++ b/PyPop/Utils.py
@@ -406,7 +406,6 @@ class StringMatrix(user_array.container):
       self.headerLines = headerLines
 
       # initialising the internal NumPy array
-      #self.array = zeros((self.rowCount, self.colCount*2+self.extraCount), PyObject)
       self.array = zeros((self.rowCount, self.colCount*2+self.extraCount), dtype='O')
       self.shape = self.array.shape
       self._dtype = self.array.dtype

--- a/PyPop/Utils.py
+++ b/PyPop/Utils.py
@@ -40,9 +40,8 @@
 """
 
 import os, sys, string, types, re, shutil, copy, operator
-import Numeric
-from Numeric import zeros, take, asarray, PyObject
-from UserArray import UserArray
+from numpy import zeros, take, asarray
+from numpy.lib import user_array
 
 GENOTYPE_SEPARATOR = "~"
 GENOTYPE_TERMINATOR= "|"
@@ -363,11 +362,15 @@ class Index:
     """
     self.i = i
 
-class StringMatrix(UserArray):
+class StringMatrix(user_array.container):
+
   """
-  StringMatrix is a subclass of the Numeric Python (NumPy)
-  UserArray class, and uses NumPy to store the data in an efficient
-  array format, rather than internal Python lists.
+  StringMatrix is a subclass of the numpy (NumPy) user_array
+  container, and uses the ndarray internally to store the data in an
+  efficient array format, rather than internal Python lists.
+
+  For more details see:
+  https://docs.scipy.org/doc/numpy/reference/arrays.classes.html
   """
 
   def __init__(self,
@@ -403,9 +406,10 @@ class StringMatrix(UserArray):
       self.headerLines = headerLines
 
       # initialising the internal NumPy array
-      self.array = zeros((self.rowCount, self.colCount*2+self.extraCount), PyObject)
+      #self.array = zeros((self.rowCount, self.colCount*2+self.extraCount), PyObject)
+      self.array = zeros((self.rowCount, self.colCount*2+self.extraCount), dtype='O')
       self.shape = self.array.shape
-      self._typecode = self.array.typecode()
+      self._dtype = self.array.dtype
       self.name = string.split(str(self.__class__))[0]
 
   def __repr__(self):
@@ -415,9 +419,9 @@ class StringMatrix(UserArray):
       a = StringMatrix(10, [1,2])
      print a"""
       if len(self.array.shape) > 0:
-          return (self.__class__.__name__)[6:12]+repr(self.array)[len("array"):]
+          return (self.__class__.__name__)+repr(self.array)[len("array"):]
       else:
-          return (self.__class__.__name__)[6:12]+"("+repr(self.array)+")"
+          return (self.__class__.__name__)+"("+repr(self.array)+")"
 
   def dump(self, locus=None, stream=sys.stdout):
       # write out file in original format
@@ -546,12 +550,12 @@ class StringMatrix(UserArray):
           col1 = col * 2
           col2 = col1 + 1
           # store each element in turn
-          self.array[(row,col1+self.extraCount)] = asarray(value1,self._typecode)
-          self.array[(row,col2+self.extraCount)] = asarray(value2,self._typecode)
+          self.array[(row,col1+self.extraCount)] = asarray(value1,self._dtype)
+          self.array[(row,col2+self.extraCount)] = asarray(value2,self._dtype)
 
       elif colName in self.extraList:
           col = self.extraList.index(colName)
-          self.array[(row,col)] = asarray(value,self._typecode)
+          self.array[(row,col)] = asarray(value,self._dtype)
       else:
           raise KeyError("can't find %s column" % col)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ exec bash -login
 
 Install the MacPorts packages
 
-      sudo port install swig-python gsl py27-numeric py-libxml2 py27-libxslt py-setuptools py27-pip
+      sudo port install swig-python gsl py27-numpy py-libxml2 py27-libxslt py-setuptools py27-pip
       
 Set MacPorts to use the just-installed 2.7 MacPorts version of Python and pip:
 
@@ -51,7 +51,7 @@ Check that the MacPorts version of Python is active by typing: ```which python``
 
 Need at least Fedora 25 for the appropriate dependencies:
 
-      sudo dnf install swig gsl-devel python-numeric python-libxml2 libxslt-python python-setuptools python-pip
+      sudo dnf install swig gsl-devel python2-numpy python-libxml2 libxslt-python python-setuptools python-pip
 
 See [DEV_NOTES.md](DEV_NOTES.md) for instructions on containerizing the install on a Centos/RHEL release.
 
@@ -59,13 +59,9 @@ See [DEV_NOTES.md](DEV_NOTES.md) for instructions on containerizing the install 
 
 Install the following packages
 
-      sudo apt install git libgsl-dev python-libxml2 python-libxslt1 python-setuptools python-pip
+      sudo apt install git libgsl-dev python-numpy python-libxml2 python-libxslt1 python-setuptools python-pip
 
-The ```python-numeric``` package is not included in the current version of Ubuntu, please see [DEV_NOTES.md](DEV_NOTES.md) for details of how to setup your repository to find ```python-numeric```, once setup, install using the following
-
-      sudo apt-get install python-numeric 
-
-The ```swig``` package in recent Ubuntu releases also has bugs, you will need to compile the most recent from source, see also [DEV_NOTES.md](DEV_NOTES.md) for details.
+The ```swig``` package in recent Ubuntu releases has bugs, you will need to compile the most recent from source, see also [DEV_NOTES.md](DEV_NOTES.md) for details.
 
 ### 4. Build
 

--- a/Singularity
+++ b/Singularity
@@ -4,7 +4,7 @@ BootStrap: yum
 OSVersion: 25
 MirrorURL: https://mirrors.kernel.org/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
 GPG: https://getfedora.org/static/FDB19C98.txt
-Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim
+Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python2-numpy python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim
 
 %setup
 	# Copy all files into a directory in the container
@@ -21,22 +21,14 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric pyt
 
 %runscript
 	#!/bin/bash
-	/usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/pypop.py $@
+	/usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/pypop.py $@
 
 %test
 	# Use the runscript to do a simple run
-	/singularity -d -c /pypop-source/data/samples/minimal.ini /pypop-source/data/samples/USAFEL-UchiTelle-small.pop
-
-	# The run output contains a date.  Strip it out.
-	sed -i -e 's|at: .*$|at: XXXXX|' USAFEL-UchiTelle-small-out.txt
-	sed -i -e 's|date=".*"|date="XXXXX"|' USAFEL-UchiTelle-small-out.xml
+	/singularity -m -c /pypop-source/data/samples/minimal.ini /pypop-source/data/samples/USAFEL-UchiTelle-small.pop
 
 	# Compare the output with our samples.  Exit if there are differences.
 	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.txt
-	if [ $? -ne 0 ]; then
-		exit 1
-	fi
-	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.xml USAFEL-UchiTelle-small-out.xml
 	if [ $? -ne 0 ]; then
 		exit 1
 	fi

--- a/data/samples/minimal.ini
+++ b/data/samples/minimal.ini
@@ -48,11 +48,6 @@ validSampleFields=+populat
 [HardyWeinberg]
 lumpBelow=5
 
-[HardyWeinbergGuoThompson]
-dememorizationSteps=2000
-samplingNum=1000
-samplingSize=1000
-
 [HardyWeinbergGuoThompsonMonteCarlo]
 monteCarloSteps=100000
 

--- a/data/singularity-test/USAFEL-UchiTelle-small-out.txt
+++ b/data/singularity-test/USAFEL-UchiTelle-small-out.txt
@@ -1,5 +1,5 @@
 Results of data analysis
-Performed on the 'USAFEL-UchiTelle-small.pop' file at: XXXXX
+Performed on the 'USAFEL-UchiTelle-small.pop' file at: 
 
 
 Population Summary
@@ -46,17 +46,17 @@ Sample Size (n): 8.0
 Allele Count (2n): 16
 Distinct alleles (k): 8
 
-Counts ordered by frequency   | Counts ordered by name        
-Name      Frequency (Count)   | Name      Frequency (Count)   
-0201      0.25000   4         | 0101      0.06250   1         
-3204      0.18750   3         | 0201      0.25000   4         
-0210      0.12500   2         | 0210      0.12500   2         
-03012     0.12500   2         | 0218      0.06250   1         
-2501      0.12500   2         | 03012     0.12500   2         
-0101      0.06250   1         | 2501      0.12500   2         
-0218      0.06250   1         | 3204      0.18750   3         
-6814      0.06250   1         | 6814      0.06250   1         
-Total     1.00000   16        | Total     1.00000   16        
+Counts ordered by freque| Counts ordered by name  
+Name  Frequency (Count) | Name  Frequency (Count) 
+0201  0.25000   4       | 0101  0.06250   1       
+3204  0.18750   3       | 0201  0.25000   4       
+0210  0.12500   2       | 0210  0.12500   2       
+03012 0.12500   2       | 0218  0.06250   1       
+2501  0.12500   2       | 03012 0.12500   2       
+0101  0.06250   1       | 2501  0.12500   2       
+0218  0.06250   1       | 3204  0.18750   3       
+6814  0.06250   1       | 6814  0.06250   1       
+Total 1.00000   16      | Total 1.00000   16      
 
 
 1.2. HardyWeinberg [A]
@@ -74,41 +74,28 @@ Table of genotypes, format of each cell is: observed/expected.
        0101  0201  0210  0218 03012  2501  3204  6814
                              [Cols: 1 to 8]
 
-                      Observed    Expected  Chi-square   DoF   p-value   
+               Observed    Expected  Chi-square   DoF   p-value   
 ------------------------------------------------------------------------------
-            Common No commmon genotypes; chi-square cannot be calculated
+     Common No commmon genotypes; chi-square cannot be calculated
 
 ------------------------------------------------------------------------------
-  Lumped genotypes Value not calculated.
+d genotypes Value not calculated.
 
 ------------------------------------------------------------------------------
-   Common + lumped Value not calculated.
+on + lumped Value not calculated.
 
 ------------------------------------------------------------------------------
- All heterozygotes           7        6.75        0.01     1  0.9233      
+terozygotes           7        6.75        0.01     1  0.9233      
 ------------------------------------------------------------------------------
 Common heterozygotes by allele
 
 ------------------------------------------------------------------------------
 Common genotypes
-             Total           0        0.00
+      Total           0        0.00
 ------------------------------------------------------------------------------
 
 
-1.3. Guo and Thompson HardyWeinberg output (mcmc) [A]
------------------------------------------------------
-Total steps in MCMC: 1000000
-Dememorization steps: 2000
-Number of Markov chain samples: 1000
-Markov chain sample size: 1000
-Std. error: 0.00437
-p-value (overall): 0.8085
-
-Individual genotype p-values found to be significant
-Genotype (observed/expected) [Chen's pval] [diff pval]
-
-
-1.4. Guo and Thompson HardyWeinberg output (monte-carlo) [A]
+1.3. Guo and Thompson HardyWeinberg output (monte-carlo) [A]
 ------------------------------------------------------------
 Steps in Monte-Carlo randomization: 100000
 p-value (overall): 0.8115
@@ -117,7 +104,7 @@ Individual genotype p-values found to be significant
 Genotype (observed/expected) [Chen's pval] [diff pval]
 
 
-1.5. Slatkin's implementation of EW homozygosity test of neutrality [A]
+1.4. Slatkin's implementation of EW homozygosity test of neutrality [A]
 -----------------------------------------------------------------------
 Observed F: 0.1562, Expected F: 0.1886, Variance in F: 0.0013
 Normalized deviate of F (Fnd): -0.9076, p-value of F: 0.2121
@@ -133,18 +120,18 @@ Sample Size (n): 10.0
 Allele Count (2n): 20
 Distinct alleles (k): 9
 
-Counts ordered by frequency   | Counts ordered by name        
-Name      Frequency (Count)   | Name      Frequency (Count)   
-0102      0.20000   4         | 0102      0.20000   4         
-0307      0.20000   4         | 02025     0.10000   2         
-02025     0.10000   2         | 0307      0.20000   4         
-0605      0.10000   2         | 0605      0.10000   2         
-0712      0.10000   2         | 0712      0.10000   2         
-1202      0.10000   2         | 0804      0.05000   1         
-1507      0.10000   2         | 1202      0.10000   2         
-0804      0.05000   1         | 1507      0.10000   2         
-1801      0.05000   1         | 1801      0.05000   1         
-Total     1.00000   20        | Total     1.00000   20        
+Counts ordered by freque| Counts ordered by name  
+Name  Frequency (Count) | Name  Frequency (Count) 
+0102  0.20000   4       | 0102  0.20000   4       
+0307  0.20000   4       | 02025 0.10000   2       
+02025 0.10000   2       | 0307  0.20000   4       
+0605  0.10000   2       | 0605  0.10000   2       
+0712  0.10000   2       | 0712  0.10000   2       
+1202  0.10000   2       | 0804  0.05000   1       
+1507  0.10000   2       | 1202  0.10000   2       
+0804  0.05000   1       | 1507  0.10000   2       
+1801  0.05000   1       | 1801  0.05000   1       
+Total 1.00000   20      | Total 1.00000   20      
 
 
 2.2. HardyWeinberg [C]
@@ -163,52 +150,38 @@ Table of genotypes, format of each cell is: observed/expected.
        0102 02025  0307  0605  0712  0804  1202  1507  1801
                              [Cols: 1 to 9]
 
-                      Observed    Expected  Chi-square   DoF   p-value   
+               Observed    Expected  Chi-square   DoF   p-value   
 ------------------------------------------------------------------------------
-            Common No commmon genotypes; chi-square cannot be calculated
+     Common No commmon genotypes; chi-square cannot be calculated
 
 ------------------------------------------------------------------------------
-  Lumped genotypes Value not calculated.
+d genotypes Value not calculated.
 
 ------------------------------------------------------------------------------
-   Common + lumped Value not calculated.
+on + lumped Value not calculated.
 
 ------------------------------------------------------------------------------
- All heterozygotes           9        8.65        0.01     1  0.9053      
+terozygotes           9        8.65        0.01     1  0.9053      
 ------------------------------------------------------------------------------
 Common heterozygotes by allele
 
 ------------------------------------------------------------------------------
 Common genotypes
-             Total           0        0.00
+      Total           0        0.00
 ------------------------------------------------------------------------------
 
 
-2.3. Guo and Thompson HardyWeinberg output (mcmc) [C]
------------------------------------------------------
-Total steps in MCMC: 1000000
-Dememorization steps: 2000
-Number of Markov chain samples: 1000
-Markov chain sample size: 1000
-Std. error: 0.006863
-p-value (overall): 0.4707
-
-Individual genotype p-values found to be significant
-Genotype (observed/expected) [Chen's pval] [diff pval]
-0712:0102:  (2/0.400000) 0.0338* 0.0361*
-
-
-2.4. Guo and Thompson HardyWeinberg output (monte-carlo) [C]
+2.3. Guo and Thompson HardyWeinberg output (monte-carlo) [C]
 ------------------------------------------------------------
 Steps in Monte-Carlo randomization: 100000
 p-value (overall): 0.4779
 
 Individual genotype p-values found to be significant
 Genotype (observed/expected) [Chen's pval] [diff pval]
-0712:0102:  (2/0.400000) 0.0347* 0.0376*
+0712+0102 (2/0.400000) 0.0347* 0.0376*
 
 
-2.5. Slatkin's implementation of EW homozygosity test of neutrality [C]
+2.4. Slatkin's implementation of EW homozygosity test of neutrality [C]
 -----------------------------------------------------------------------
 Observed F: 0.1350, Expected F: 0.1789, Variance in F: 0.0014
 Normalized deviate of F (Fnd): -1.1641, p-value of F: 0.0668
@@ -224,10 +197,10 @@ Sample Size (n): 9.0
 Allele Count (2n): 18
 Distinct alleles (k): 1
 
-Counts ordered by frequency   | Counts ordered by name        
-Name      Frequency (Count)   | Name      Frequency (Count)   
-1301      1.00000   18        | 1301      1.00000   18        
-Total     1.00000   18        | Total     1.00000   18        
+Counts ordered by frequ| Counts ordered by name 
+Name Frequency (Count) | Name Frequency (Count) 
+1301 1.00000   18      | 1301 1.00000   18      
+Total1.00000   18      | Total1.00000   18      
 
 [Locus is monomorphic, so no further analyses performed]
 
@@ -243,9 +216,9 @@ __________________________________________________
 Pairwise LD estimates
 ---------------------
 Locus pair            D      D'        Wn   ln(L_1)   ln(L_0)         S # permu p-value
-A:C             0.02734 0.88530   0.77023    -36.04    -55.27     38.45       - -      
-A:B             0.00000 0.00000      -nan    -26.51    -26.51      0.00       - -      
-C:B             0.00000 0.00000      -nan    -32.10    -32.10      0.00       - -      
+A:C             0.04309 1.20192   2.43975    -36.04    -50.35     28.61       - -      
+A:B                -nan     inf       inf    -26.51    -28.42      3.82       - -      
+C:B                -nan     inf       inf    -32.10    -21.53    -21.13       - -      
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ particularly large-scale multilocus genotype data""",
        platforms = ["GNU/Linux", "Windows", "MacOS"],
        packages = ["PyPop"],
        # install_requires = [
-       #  'Numeric',
+       #  'numpy',
        #  'libxml2-python'
        #  ],
        scripts= ['bin/pypop.py', 'bin/popmeta.py'],


### PR DESCRIPTION
I have a preliminary port from ```Numeric``` to ```numpy``` (#2).   This should make it a lot easier to build, package for PyPI and maintain going forward.  I've also updated the Singularity build script accordingly.  @akkornel & @vsoch, please do give it whirl and see if it builds for you.

@sjmack: please do also try this branch and see if all your files still work.  You'll need to use MacPorts to add the ```py27-numpy``` dependency (this is described in the README.md):

     sudo port install py27-numpy

Then switch to this branch and rebuild:

     git checkout numpy-port
     ./setup.py clean --all
     ./setup.py build

I've run everything through our current test suite and it all seems to be work, but with a major dependency change, would be good to have as many runs as possible. 