### PR TITLE
Singularity container bootstrap updates

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -14,7 +14,7 @@ From: fedora:25
 
 %post
 	# Inside the container, install our required packages.
-	dnf install -y swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim findutils
+	dnf install -y python27 python-devel python-numeric python-libxml2 libxslt-python gcc redhat-rpm-config gsl-devel swig less findutils vim
 
 	# Now, build PyPop.
 	# (to be clear, the installs pypop into the container Python)

--- a/Singularity
+++ b/Singularity
@@ -49,7 +49,32 @@ From: fedora:25
 
 %runscript
 	#!/bin/bash
-	/usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/pypop.py $@
+	if [ "$#" = '0' ]; then
+		echo 'You did not choose a program to run!'
+		echo 'Please re-run this command, but add the word...'
+		echo '    "pypop"   (to run PyPop), or'
+		echo '    "popmeta" (to run PopMeta).'
+		echo 'Then add your normal command-line arguments.'
+		echo 'Thanks!'
+		exit 1
+	fi
+	case $1 in
+	pypop)
+		shift
+		exec /usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/pypop.py $@
+		;;
+	popmeta)
+		shift
+		exec /usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/popmeta.py $@
+		;;
+	*)
+		echo "I'm sorry, I did not recognize what program you wanted to run!"
+		echo "Please place 'pypop' or 'popmeta' at the start of your argument list,"
+		echo 'followed by the normal pypop or popmeta arguments.'
+		echo 'Thanks!'
+		exit 1
+		;;
+	esac
 
 %test
 	# Use the runscript to do a simple run

--- a/Singularity
+++ b/Singularity
@@ -52,7 +52,11 @@ From: fedora:25
 
 %test
 	# Use the runscript to do a simple run
-	/singularity -m -c /pypop-source/data/samples/minimal.ini /pypop-source/data/samples/USAFEL-UchiTelle-small.pop
+	/singularity -d -c /pypop-source/data/samples/minimal.ini /pypop-source/data/samples/USAFEL-UchiTelle-small.pop
+
+	# The run output contains a date.  Strip it out.
+	#sed -i -e 's|at: .*$|at: XXXXX|' USAFEL-UchiTelle-small-out.txt
+	#sed -i -e 's|date=".*"|date="XXXXX"|' USAFEL-UchiTelle-small-out.xml
 
 	# Compare the output with our samples.  Exit if there are differences.
     # NOTE: Tests disabled because some output variance is apparently expected.

--- a/Singularity
+++ b/Singularity
@@ -5,11 +5,16 @@ From: fedora:25
 
 %setup
 	# Copy all files into a directory in the container
-	# (We use -rlptD instead of -a because owner & group can be ignored.)
+	# Make destination directories (code, and a place for logs)
 	mkdir ${SINGULARITY_ROOTFS}/pypop-source
 	mkdir ${SINGULARITY_ROOTFS}/.bootstrap_logs
 	echo $PWD > ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pwd
+
+	# Use rsync to copy the files into the container
+	# (We use -rlptD instead of -a because owner & group can be ignored.)
 	rsync -v -rlptD . ${SINGULARITY_ROOTFS}/pypop-source/ 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_rsync_output
+
+	# Output some debug file listings
 	ls -lR . 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_from_host
 	ls -lR ${SINGULARITY_ROOTFS}/pypop-source 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_in_rootfs
 

--- a/Singularity
+++ b/Singularity
@@ -14,7 +14,7 @@ From: fedora:25
 	# Use rsync to copy the files into the container
 	# (We use -rlptD instead of -a because owner & group can be ignored.)
 	echo 'BOOTSTRAP[SETUP]: Copying files'
-	rsync -v -rlptD . ${SINGULARITY_ROOTFS}/pypop-source/ 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_rsync_output
+	rsync -v -rlptD --exclude image . ${SINGULARITY_ROOTFS}/pypop-source/ 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_rsync_output
 
 	# Output some debug file listings
 	echo 'BOOTSTRAP[SETUP]: Source listing (from host)'

--- a/Singularity
+++ b/Singularity
@@ -28,7 +28,7 @@ From: ubuntu:17.04
 %post
     # Inside the container, install our required packages.
     apt update
-    apt install --no-install-recommends -y build-essential libgsl2 libgsl-dev libpcre3 libpcre3-dev python2.7-dev python-numpy python-libxml2 python-libxslt1 python-pip python-pytest python-setuptools
+    apt install --no-install-recommends -y build-essential libboost-dev libgsl2 libgsl-dev libpcre3 libpcre3-dev python2.7-dev python-numpy python-libxml2 python-libxslt1 python-pip python-pytest python-setuptools
 
     # Build and install SWIG 3.0.12
     tar -xzvf /swig-3.0.12.tar.gz

--- a/Singularity
+++ b/Singularity
@@ -25,6 +25,7 @@ From: fedora:25
 %post
 	# Inside the container, install our required packages.
 	echo 'BOOTSTRAP[POST]: Installing packages'
+	echo 'deltarpm=0' >> /etc/dnf/dnf.conf
 	dnf install -y python27 python-devel python-numeric python-libxml2 libxslt-python gcc redhat-rpm-config gsl-devel swig less findutils vim 2>&1 | tee /.bootstrap_logs/dnf_install
 
 	# Now, build PyPop.

--- a/Singularity
+++ b/Singularity
@@ -1,10 +1,7 @@
 # vim: ts=4 sw=4 noet
 
-BootStrap: yum
-OSVersion: 25
-MirrorURL: https://mirrors.kernel.org/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
-GPG: https://getfedora.org/static/FDB19C98.txt
-Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim findutils
+BootStrap: docker
+From: fedora:25
 
 %setup
 	# Copy all files into a directory in the container
@@ -16,7 +13,10 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric pyt
 	ls -lR ${SINGULARITY_ROOTFS}/pypop-source > ${SINGULARITY_ROOTFS}/.pypop_listing_from_setup
 
 %post
-	# Inside the container, build pypop
+	# Inside the container, install our required packages.
+	yum install -y swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim findutils
+
+	# Now, build PyPop.
 	# (to be clear, the installs pypop into the container Python)
 	ls -lR /pypop-source > /.pypop_listing_from_post
 	cd /pypop-source

--- a/Singularity
+++ b/Singularity
@@ -27,6 +27,11 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric pyt
     chmod -R go+r /pypop-source
     find /pypop-source -type d -exec chmod go+x {} +
 
+    # Make everything group- and world-readable
+    # Also make directories group and world-executable.
+    chmod -R go+r /pypop-source
+    find /pypop-source -type d -exec chmod go+x {} +
+
 %runscript
 	#!/bin/bash
 	/usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/pypop.py $@

--- a/Singularity
+++ b/Singularity
@@ -4,7 +4,7 @@ BootStrap: yum
 OSVersion: 25
 MirrorURL: https://mirrors.kernel.org/fedora/releases/%{OSVERSION}/Everything/x86_64/os/
 GPG: https://getfedora.org/static/FDB19C98.txt
-Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python2-numpy python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim
+Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim findutils
 
 %setup
 	# Copy all files into a directory in the container
@@ -18,6 +18,11 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python2-numpy pyth
 	# (to be clear, the installs pypop into the container Python)
 	cd /pypop-source
 	./setup.py build
+
+    # Make everything group- and world-readable
+    # Also make directories group and world-executable.
+    chmod -R go+r /pypop-source
+    find /pypop-source -type d -exec chmod go+x {} +
 
 %runscript
 	#!/bin/bash

--- a/Singularity
+++ b/Singularity
@@ -11,13 +11,17 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric pyt
 	# (Make sure to exclude our Singularity image file)
 	# (We use -rlptD instead of -a because owner & group can be ignored.)
 	mkdir ${SINGULARITY_ROOTFS}/pypop-source
-	rsync -rlptD --exclude '*.img' . ${SINGULARITY_ROOTFS}/pypop-source/
+	echo $PWD > ${SINGULARITY_ROOTFS}/.pwd
+	rsync -v -rlptD --exclude '*.img' . ${SINGULARITY_ROOTFS}/pypop-source/ > ${SINGULARITY_ROOTFS}/.rsync_output
+	ls -lR . > ${SINGULARITY_ROOTFS}/.pypop_listing_from_host
+	ls -lR ${SINGULARITY_ROOTFS}/pypop-source > ${SINGULARITY_ROOTFS}/.pypop_listing_from_setup
 
 %post
 	# Inside the container, build pypop
 	# (to be clear, the installs pypop into the container Python)
+	ls -lR /pypop-source > /.pypop_listing_from_post
 	cd /pypop-source
-	./setup.py build
+	./setup.py build > /.pypop_build
 
     # Make everything group- and world-readable
     # Also make directories group and world-executable.

--- a/Singularity
+++ b/Singularity
@@ -8,9 +8,9 @@ From: fedora:25
 	# (We use -rlptD instead of -a because owner & group can be ignored.)
 	mkdir ${SINGULARITY_ROOTFS}/pypop-source
 	echo $PWD > ${SINGULARITY_ROOTFS}/.pwd
-	rsync -v -rlptD . ${SINGULARITY_ROOTFS}/pypop-source/ > ${SINGULARITY_ROOTFS}/.rsync_output
-	ls -lR . > ${SINGULARITY_ROOTFS}/.pypop_listing_from_host
-	ls -lR ${SINGULARITY_ROOTFS}/pypop-source > ${SINGULARITY_ROOTFS}/.pypop_listing_from_setup
+	rsync -v -rlptD . ${SINGULARITY_ROOTFS}/pypop-source/ > ${SINGULARITY_ROOTFS}/.rsync_output 2>&1
+	ls -lR . > ${SINGULARITY_ROOTFS}/.pypop_listing_from_host 2>&1
+	ls -lR ${SINGULARITY_ROOTFS}/pypop-source > ${SINGULARITY_ROOTFS}/.pypop_listing_from_setup 2>&1
 
 %post
 	# Inside the container, install our required packages.
@@ -18,9 +18,9 @@ From: fedora:25
 
 	# Now, build PyPop.
 	# (to be clear, the installs pypop into the container Python)
-	ls -lR /pypop-source > /.pypop_listing_from_post
+	ls -lR /pypop-source > /.pypop_listing_from_post 2>&1
 	cd /pypop-source
-	./setup.py build > /.pypop_build
+	./setup.py build > /.pypop_build 2>&1
 
     # Make everything group- and world-readable
     # Also make directories group and world-executable.

--- a/Singularity
+++ b/Singularity
@@ -6,30 +6,38 @@ From: fedora:25
 %setup
 	# Copy all files into a directory in the container
 	# Make destination directories (code, and a place for logs)
+	echo 'BOOTSTRAP[SETUP]: Creating directories'
 	mkdir ${SINGULARITY_ROOTFS}/pypop-source
 	mkdir ${SINGULARITY_ROOTFS}/.bootstrap_logs
 	echo $PWD > ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pwd
 
 	# Use rsync to copy the files into the container
 	# (We use -rlptD instead of -a because owner & group can be ignored.)
+	echo 'BOOTSTRAP[SETUP]: Copying files'
 	rsync -v -rlptD . ${SINGULARITY_ROOTFS}/pypop-source/ 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_rsync_output
 
 	# Output some debug file listings
+	echo 'BOOTSTRAP[SETUP]: Source listing (from host)'
 	ls -lR . 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_from_host
+	echo 'BOOTSTRAP[SETUP]: Source listing (from rootfs)'
 	ls -lR ${SINGULARITY_ROOTFS}/pypop-source 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_in_rootfs
 
 %post
 	# Inside the container, install our required packages.
+	echo 'BOOTSTRAP[POST]: Installing packages'
 	dnf install -y python27 python-devel python-numeric python-libxml2 libxslt-python gcc redhat-rpm-config gsl-devel swig less findutils vim 2>&1 | tee /.bootstrap_logs/dnf_install
 
 	# Now, build PyPop.
 	# (to be clear, the installs pypop into the container Python)
+	echo 'BOOTSTRAP[POST]: Source listing (inside container)'
 	ls -lR /pypop-source 2>&1 | tee /.bootstrap_logs/pypop_listing_from_post
+	echo 'BOOTSTRAP[POST]: Building PyPop'
 	cd /pypop-source
 	./setup.py build 2>&1 | tee /.bootstrap_logs/pypop_build
 
     # Make everything group- and world-readable
     # Also make directories group and world-executable.
+	echo 'BOOTSTRAP[POST]: Fixing up permissions'
     chmod -R go+r /pypop-source
     find /pypop-source -type d -exec chmod go+x {} +
 

--- a/Singularity
+++ b/Singularity
@@ -28,10 +28,9 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python2-numpy pyth
 	/singularity -m -c /pypop-source/data/samples/minimal.ini /pypop-source/data/samples/USAFEL-UchiTelle-small.pop
 
 	# Compare the output with our samples.  Exit if there are differences.
-	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.txt
-	if [ $? -ne 0 ]; then
-		exit 1
-	fi
+    # NOTE: Tests disabled because some output variance is apparently expected.
+	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.txt || true
+	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.xml USAFEL-UchiTelle-small-out.xml || true
 
 	# Clean up!
 	rm USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.xml

--- a/Singularity
+++ b/Singularity
@@ -56,8 +56,8 @@ From: fedora:25
 
 	# Compare the output with our samples.  Exit if there are differences.
     # NOTE: Tests disabled because some output variance is apparently expected.
-	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.txt || true
-	diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.xml USAFEL-UchiTelle-small-out.xml || true
+	#diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.txt || true
+	#diff -u /pypop-source/data/singularity-test/USAFEL-UchiTelle-small-out.xml USAFEL-UchiTelle-small-out.xml || true
 
 	# Clean up!
 	rm USAFEL-UchiTelle-small-out.txt USAFEL-UchiTelle-small-out.xml

--- a/Singularity
+++ b/Singularity
@@ -8,11 +8,10 @@ Include: swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric pyt
 
 %setup
 	# Copy all files into a directory in the container
-	# (Make sure to exclude our Singularity image file)
 	# (We use -rlptD instead of -a because owner & group can be ignored.)
 	mkdir ${SINGULARITY_ROOTFS}/pypop-source
 	echo $PWD > ${SINGULARITY_ROOTFS}/.pwd
-	rsync -v -rlptD --exclude '*.img' . ${SINGULARITY_ROOTFS}/pypop-source/ > ${SINGULARITY_ROOTFS}/.rsync_output
+	rsync -v -rlptD . ${SINGULARITY_ROOTFS}/pypop-source/ > ${SINGULARITY_ROOTFS}/.rsync_output
 	ls -lR . > ${SINGULARITY_ROOTFS}/.pypop_listing_from_host
 	ls -lR ${SINGULARITY_ROOTFS}/pypop-source > ${SINGULARITY_ROOTFS}/.pypop_listing_from_setup
 

--- a/Singularity
+++ b/Singularity
@@ -14,7 +14,7 @@ From: fedora:25
 
 %post
 	# Inside the container, install our required packages.
-	yum install -y swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim findutils
+	dnf install -y swig gcc.x86_64 gsl-devel.x86_64 python-devel.x86_64 python-numeric python-libxml2 libxslt-python redhat-rpm-config yum rpm.x86_64 vim findutils
 
 	# Now, build PyPop.
 	# (to be clear, the installs pypop into the container Python)

--- a/Singularity
+++ b/Singularity
@@ -1,60 +1,60 @@
-# vim: ts=4 sw=4 noet
+# vim: ts=4 sw=4 et
 
 BootStrap: docker
 From: ubuntu:17.04
 
 %setup
-	# Copy all files into a directory in the container
-	# Make destination directories (code, and a place for logs)
-	echo 'BOOTSTRAP[SETUP]: Creating directories'
-	mkdir ${SINGULARITY_ROOTFS}/pypop-source
-	mkdir ${SINGULARITY_ROOTFS}/.bootstrap_logs
-	echo $PWD > ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pwd
+    # Copy all files into a directory in the container
+    # Make destination directories (code, and a place for logs)
+    echo 'BOOTSTRAP[SETUP]: Creating directories'
+    mkdir ${SINGULARITY_ROOTFS}/pypop-source
+    mkdir ${SINGULARITY_ROOTFS}/.bootstrap_logs
+    echo $PWD > ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pwd
 
-	# Use rsync to copy the files into the container
-	# (We use -rlptD instead of -a because owner & group can be ignored.)
-	echo 'BOOTSTRAP[SETUP]: Copying files'
-	rsync -v -rlptD --exclude image . ${SINGULARITY_ROOTFS}/pypop-source/ 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_rsync_output
+    # Use rsync to copy the files into the container
+    # (We use -rlptD instead of -a because owner & group can be ignored.)
+    echo 'BOOTSTRAP[SETUP]: Copying files'
+    rsync -v -rlptD --exclude image . ${SINGULARITY_ROOTFS}/pypop-source/ 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_rsync_output
 
-	# Download swig
-	curl -L -o ${SINGULARITY_ROOTFS}/swig-3.0.12.tar.gz http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz
+    # Download swig
+    curl -L -o ${SINGULARITY_ROOTFS}/swig-3.0.12.tar.gz http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz
 
-	# Output some debug file listings
-	echo 'BOOTSTRAP[SETUP]: Source listing (from host)'
-	ls -lR . 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_from_host
-	echo 'BOOTSTRAP[SETUP]: Source listing (from rootfs)'
-	ls -lR ${SINGULARITY_ROOTFS}/pypop-source 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_in_rootfs
+    # Output some debug file listings
+    echo 'BOOTSTRAP[SETUP]: Source listing (from host)'
+    ls -lR . 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_from_host
+    echo 'BOOTSTRAP[SETUP]: Source listing (from rootfs)'
+    ls -lR ${SINGULARITY_ROOTFS}/pypop-source 2>&1 | tee ${SINGULARITY_ROOTFS}/.bootstrap_logs/setup_pypop_listing_in_rootfs
 
 %post
-	# Inside the container, install our required packages.
-	apt update
-	apt install --no-install-recommends -y build-essential libgsl2 libgsl-dev libpcre3 libpcre3-dev python2.7-dev python-numpy python-libxml2 python-libxslt1 python-pip python-pytest python-setuptools
+    # Inside the container, install our required packages.
+    apt update
+    apt install --no-install-recommends -y build-essential libgsl2 libgsl-dev libpcre3 libpcre3-dev python2.7-dev python-numpy python-libxml2 python-libxslt1 python-pip python-pytest python-setuptools
 
-	# Build and install SWIG 3.0.12
-	tar -xzvf /swig-3.0.12.tar.gz
-	cd /swig-3.0.12
-	./configure --without-alllang --with-python
-	make
-	make install
+    # Build and install SWIG 3.0.12
+    tar -xzvf /swig-3.0.12.tar.gz
+    cd /swig-3.0.12
+    ./configure --without-alllang --with-python
+    make
+    make install
 
-	# Now, build PyPop.
-	# (to be clear, the installs pypop into the container Python)
-	echo 'BOOTSTRAP[POST]: Source listing (inside container)'
-	ls -lR /pypop-source 2>&1 | tee /.bootstrap_logs/pypop_listing_from_post
-	echo 'BOOTSTRAP[POST]: Building PyPop'
-	cd /pypop-source
-	./setup.py build 2>&1 | tee /.bootstrap_logs/pypop_build
+    # Now, build PyPop.
+    # (to be clear, the installs pypop into the container Python)
+    echo 'BOOTSTRAP[POST]: Source listing (inside container)'
+    ls -lR /pypop-source 2>&1 | tee /.bootstrap_logs/pypop_listing_from_post
+    echo 'BOOTSTRAP[POST]: Building PyPop'
+    cd /pypop-source
+    ./setup.py build 2>&1 | tee /.bootstrap_logs/pypop_build
 
-	# Do some cleanup
-	cd /
-	rm -rf swig-3.0.12 swig-3.0.12.tar.gz
-	apt purge -y build-essential libgsl-dev libpcre3-dev python2.7-dev
-	apt autoremove -y
-	apt clean
+    # Do some cleanup
+    cd /
+    rm -rf swig-3.0.12 swig-3.0.12.tar.gz
+    apt purge -y build-essential libgsl-dev libpcre3-dev python2.7-dev
+    apt autoremove -y
+    apt clean
 
     # Make everything group- and world-readable
     # Also make directories group and world-executable.
-	echo 'BOOTSTRAP[POST]: Fixing up permissions'
+    echo 'BOOTSTRAP[POST]: Fixing up permissions'
     chmod -R go+r /pypop-source
     find /pypop-source -type d -exec chmod go+x {} +
 
@@ -64,35 +64,35 @@ From: ubuntu:17.04
     find /pypop-source -type d -exec chmod go+x {} +
 
 %runscript
-	#!/bin/bash
-	if [ "$#" = '0' ]; then
-		echo 'You did not choose a program to run!'
-		echo 'Please re-run this command, but add the word...'
-		echo '    "pypop"   (to run PyPop), or'
-		echo '    "popmeta" (to run PopMeta).'
-		echo 'Then add your normal command-line arguments.'
-		echo 'Thanks!'
-		exit 1
-	fi
-	case $1 in
-	pypop)
-		shift
-		exec /usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/pypop.py $@
-		;;
-	popmeta)
-		shift
-		exec /usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/popmeta.py $@
-		;;
-	*)
-		echo "I'm sorry, I did not recognize what program you wanted to run!"
-		echo "Please place 'pypop' or 'popmeta' at the start of your argument list,"
-		echo 'followed by the normal pypop or popmeta arguments.'
-		echo 'Thanks!'
-		exit 1
-		;;
-	esac
+    #!/bin/bash
+    if [ "$#" = '0' ]; then
+        echo 'You did not choose a program to run!'
+        echo 'Please re-run this command, but add the word...'
+        echo '    "pypop"   (to run PyPop), or'
+        echo '    "popmeta" (to run PopMeta).'
+        echo 'Then add your normal command-line arguments.'
+        echo 'Thanks!'
+        exit 1
+    fi
+    case $1 in
+    pypop)
+        shift
+        exec /usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/pypop.py $@
+        ;;
+    popmeta)
+        shift
+        exec /usr/bin/env PYTHONPATH=/pypop-source /usr/bin/python2.7 /pypop-source/bin/popmeta.py $@
+        ;;
+    *)
+        echo "I'm sorry, I did not recognize what program you wanted to run!"
+        echo "Please place 'pypop' or 'popmeta' at the start of your argument list,"
+        echo 'followed by the normal pypop or popmeta arguments.'
+        echo 'Thanks!'
+        exit 1
+        ;;
+    esac
 
 %test
-	# Use py.test
-	cd /pypop-source
-	/usr/bin/py.test -s -v
+    # Use py.test
+    cd /pypop-source
+    /usr/bin/py.test -s -v


### PR DESCRIPTION
This PR has a number of changes to the Singularity bootstrap file:

• Ubuntu 17.04 is now being used as the base.
• SWIG 3.0.12 is being downloaded and built into the container, before PyPop builds.
• Some additional dependencies (packages) are being installed (for SWIG).
• Once building is complete, header files are removed from the container.
• py.test is now used for the tests.

With these changes, the container is now able to build using Singularity Hub!