### PR TITLE
fix numpy + regex warnings

### DIFF
--- a/src/PyPop/Arlequin.py
+++ b/src/PyPop/Arlequin.py
@@ -368,10 +368,10 @@ KeepNullDistrib=0"""
         dataFound = 0
         headerFound = 0
 
-        patt1 = re.compile("Exact test using a Markov chain")
-        patt2 = re.compile("Locus  #Genot     Obs.Heter.   Exp.Heter.  P. value     s.d.  Steps done")
-        patt3 = re.compile("^\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)")
-        patt4 = re.compile("^\s+(\d+)\s+This locus is monomorphic: no test done.")
+        patt1 = re.compile(r"Exact test using a Markov chain")
+        patt2 = re.compile(r"Locus  #Genot     Obs.Heter.   Exp.Heter.  P. value     s.d.  Steps done")
+        patt3 = re.compile(r"^\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\d+)")
+        patt4 = re.compile(r"^\s+(\d+)\s+This locus is monomorphic: no test done.")
 
         hwExact = {}
         

--- a/src/PyPop/Haplo.py
+++ b/src/PyPop/Haplo.py
@@ -752,11 +752,11 @@ def _compute_LD(haplos, freqs, compute_ALD=False, debug=False):
         F_2 = 0.0
         F_1_2 = 0.0
         for i in numpy.unique(alleles1):
-           af_1 = numpy.unique(a_freq1[alleles1==i])
+           af_1 = numpy.unique(a_freq1[alleles1==i])[0]  # take the first element of ndarray
            F_1 = F_1 + af_1**2
            F_2_1 = F_2_1 + ((hap_prob[alleles1==i]**2)/af_1).sum()
         for i in numpy.unique(alleles2):
-           af_2 = numpy.unique(a_freq2[alleles2==i])
+           af_2 = numpy.unique(a_freq2[alleles2==i])[0]
            F_2 = F_2 + af_2**2
            F_1_2 = F_1_2 + ((hap_prob[alleles2==i]**2)/af_2).sum()
         if F_2 == 1.0:
@@ -764,13 +764,13 @@ def _compute_LD(haplos, freqs, compute_ALD=False, debug=False):
            ALD_2_1 = numpy.nan
         else:
            F_2_1_prime = (F_2_1 - F_2)/(1 - F_2)
-           ALD_2_1 = math.sqrt(F_2_1_prime[0])
+           ALD_2_1 = math.sqrt(F_2_1_prime)
         if F_1 == 1:
            F_1_2_prime = numpy.nan
            ALD_1_2 = numpy.nan
         else:
            F_1_2_prime = (F_1_2 - F_1)/(1 - F_1)
-           ALD_1_2 = math.sqrt(F_1_2_prime[0])
+           ALD_1_2 = math.sqrt(F_1_2_prime)
         if debug:
             print ("ALD_1_2:", ALD_1_2)
             print ("ALD_2_1:", ALD_2_1)

--- a/src/PyPop/Haplo.py
+++ b/src/PyPop/Haplo.py
@@ -764,13 +764,13 @@ def _compute_LD(haplos, freqs, compute_ALD=False, debug=False):
            ALD_2_1 = numpy.nan
         else:
            F_2_1_prime = (F_2_1 - F_2)/(1 - F_2)
-           ALD_2_1 = math.sqrt(F_2_1_prime)
+           ALD_2_1 = math.sqrt(F_2_1_prime[0])
         if F_1 == 1:
            F_1_2_prime = numpy.nan
            ALD_1_2 = numpy.nan
         else:
            F_1_2_prime = (F_1_2 - F_1)/(1 - F_1)
-           ALD_1_2 = math.sqrt(F_1_2_prime)
+           ALD_1_2 = math.sqrt(F_1_2_prime[0])
         if debug:
             print ("ALD_1_2:", ALD_1_2)
             print ("ALD_2_1:", ALD_2_1)

--- a/src/PyPop/Haplo.py
+++ b/src/PyPop/Haplo.py
@@ -752,7 +752,7 @@ def _compute_LD(haplos, freqs, compute_ALD=False, debug=False):
         F_2 = 0.0
         F_1_2 = 0.0
         for i in numpy.unique(alleles1):
-           af_1 = numpy.unique(a_freq1[alleles1==i])[0]  # take the first element of ndarray
+           af_1 = numpy.unique(a_freq1[alleles1==i])[0]  # take the first element of ndarray (default behaviour)
            F_1 = F_1 + af_1**2
            F_2_1 = F_2_1 + ((hap_prob[alleles1==i]**2)/af_1).sum()
         for i in numpy.unique(alleles2):

--- a/src/PyPop/Haplo.py
+++ b/src/PyPop/Haplo.py
@@ -249,9 +249,9 @@ KeepNullDistrib=0""")
 
         haplotypes = []
         
-        patt1 = re.compile("== Sample :[\t ]*(\S+) pop with (\d+) individuals from loci \[([^]]+)\]")
-        patt2 = re.compile("    #   Haplotype     Freq.      s.d.")
-        patt3 = re.compile("^\s+\d+\s+UNKNOWN(.*)")
+        patt1 = re.compile(r"== Sample :[\t ]*(\S+) pop with (\d+) individuals from loci \[([^]]+)\]")
+        patt2 = re.compile(r"    #   Haplotype     Freq.      s.d.")
+        patt3 = re.compile(r"^\s+\d+\s+UNKNOWN(.*)")
         windowRange = range(1, self.windowSize)
         
         for line in open(outFile, 'r').readlines():

--- a/src/PyPop/Utils.py
+++ b/src/PyPop/Utils.py
@@ -738,7 +738,7 @@ class Group:
 
 ### global FUNCTIONS start here
 
-def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+def natural_sort_key(s, _nsre=re.compile(r'([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower()
             for text in re.split(_nsre, s)]
 


### PR DESCRIPTION
@rsingle I noticed that the calls to `math.sqrt` were producing `numpy` warnings.  I think this is due to being passed an `ndarray` rather than a scalar, so I modified this to take the first element of the `F_2_1_prime` or `F_1_2_prime`, but I'm not sure if this is generalizable solution.  Not sure why those variables are arrays in the first place.