### PR TITLE
piccolo-theme fixed: pin sphinx version to 7.2.5

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-python@v4
       - name: Install dependencies
         run: |
-          pip install setuptools_scm sphinx==7.1.2 piccolo-theme sphinx_rtd_theme myst_parser rst2pdf sphinx_togglebutton sphinx-argparse sphinx_copybutton
+          pip install setuptools_scm sphinx==7.2.5 piccolo-theme sphinx_rtd_theme myst_parser rst2pdf sphinx_togglebutton sphinx-argparse sphinx_copybutton
           sudo apt clean
           sudo apt-get update
           sudo apt-get install --fix-missing -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra texlive-luatex texlive-xetex


### PR DESCRIPTION
piccolo-theme is now compatible with sphinx > 7.2 (https://github.com/piccolo-orm/piccolo_theme/issues/61), pinning most recent version