### PR TITLE
End-user warning that undocumented module `[Haplostats]` is not yet supported

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,5 +1,12 @@
 # Developer notes
 
+## Release notes for in-progress features not yet officially documented or supported
+
+* New wrapper module `Haplostats`. This wraps a portion of the
+  `haplo.stats` R package `haplo-stats` for haplotype
+  estimation. [Implementation in alpha-phase].
+
+
 ## External dependencies
 
 * ```swig``` (Simple Wrapper Interface Generator) (build-time only)
@@ -40,8 +47,8 @@ the) it then runs the specified modules (outlined below).
 "wxPython":http://www.wxpython.org GUI toolkit.  wxPython is a set of
 Python bindings to "wxWindows":http://www.wxwindows.org, which is an
 open-source cross-platform GUI widget toolkit which has a native look
-under GNU/Linux (GTK), Windows (MFC) and MacOS X (Aqua).  [as of 2017,
-this is deprecated]
+under GNU/Linux (GTK), Windows (MFC) and MacOS X (Aqua).  [as of 2023,
+this was removed]
 
 * 'ParseFile' is a base class which has most of the common functionality
 for reading files.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,9 +11,6 @@ New features
 ^^^^^^^^^^^^^^
 * Updated to Python 3
 * Implement new assymetric LD (ALD) measure
-* New wrapper module ``Haplostats``. This wraps a portion of the
-  ``haplo.stats`` R package ``haplo-stats`` for haplotype
-  estimation. [Implementation in alpha-phase].
 * ``popmeta``: now accepts the ``-o``/``--outputdir`` option for saving
   generated files.
 * ``pypop``: renamed ``--generate-tsv`` to ``--enable-tsv``

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ setup (name = __pkgname__,
        url = "http://www.pypop.org/",
        project_urls={
            'Documentation': 'http://pypop.org/docs/',
+           'Changelog': 'https://github.com/alexlancaster/pypop/blob/main/NEWS.rst',
            'Source': 'https://github.com/alexlancaster/pypop/',
            'Tracker': 'https://github.com/alexlancaster/pypop/issues',
        },

--- a/src/PyPop/Main.py
+++ b/src/PyPop/Main.py
@@ -1017,6 +1017,9 @@ class Main:
 
         if self.config.has_section("Haplostats"):
 
+            print ("WARNING: The [Haplostats] module is still currently in ALPHA-MODE ONLY and and should not be used in production.")
+            print ("Please use the [Emhaplofreq] module in the meantime.")
+            
             try:
                 numInitCond = self.config.getint("Haplostats",
                                                  "numInitCond")
@@ -1075,9 +1078,6 @@ class Main:
         # files.
 
         if self.config.has_section("Emhaplofreq"):
-
-          print ("WARNING: The [Emhaplofreq] module is officially DEPRECATED and may be removed in coming releases.")
-          print ("Please transition to using the new [Haplostats] module.")
 
           # create object to generate haplotype and LD statistics
           # a wrapper around the emhaplofreq module
@@ -1148,11 +1148,11 @@ at least 1000 is recommended.  A value of '1' is not permitted.""")
 
 
           if allPairwiseLD:
-            print("LOG: estimating all pairwise LD:"),
+            print("LOG: estimating all pairwise LD:", end=" "),
             if allPairwiseLDWithPermu:
-              print("with %d permutations and %d initial conditions for each permutation" % (allPairwiseLDWithPermu, numPermuInitCond)),
+              print("with %d permutations and %d initial conditions for each permutation" % (allPairwiseLDWithPermu, numPermuInitCond), end=" "),
               if permutationPrintFlag:
-                  print("and each permutation output will be logged to XML")
+                  print("and each permutation output will be logged to XML", end=" ")
               else:
                   print()
             else:
@@ -1166,15 +1166,15 @@ at least 1000 is recommended.  A value of '1' is not permitted.""")
             locusKeys=self.config.get("Emhaplofreq", "lociToEstHaplo")
 
             if locusKeys == '*':
-              print("wildcard '*' given for lociToEstHaplo, assume entire data set")
+              print("LOG: wildcard '*' given for lociToEstHaplo, assume entire data set")
               locusKeys=":".join(self.input.getIndividualsData().colList)
-            print("LOG: estimating haplotype frequencies for"),
+            print("LOG: estimating haplotype frequencies for", end=" "),
 
             # if we will be running allPairwise*, then exclude any two-locus
             # haplotypes, since we will estimate them as part of 'all pairwise'
             if allPairwiseLD:
 
-              print("all two locus haplotypes,"),
+              print("all two locus haplotypes,", end=" "),
               modLocusKeys = []
               for group in locusKeys.split(','):
 


### PR DESCRIPTION
Also disables the `[Emhaplofreq]` deprecation for the time being (being deferred until `[Haplostats]` is fully documented/tested).