### PR TITLE
Zenodo upload infrastructure

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -199,12 +199,13 @@ jobs:
         id: recreate_release
         uses: joutvhu/create-release@v1
         with:
-          tag_name: $GITHUB_REF_NAME
+          tag_name: ${{ github.event.release.tag_name }}
           name: ${{ steps.get_existing_release.outputs.name }}
           body: ${{ steps.get_existing_release.outputs.body }}
           draft: ${{ steps.get_existing_release.outputs.draft }}
           prerelease: ${{ steps.get_existing_release.outputs.draft }}
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
+          on_release_exists: update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,16 +72,16 @@ jobs:
       - name: Create a draft snapshot of your repository contents as a new
               version in test collection on Zenodo using metadata
               from repository file .zenodo.json
+        #
+        # DISABLE uploading via zenodraft action, currently
+        #
+        if: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # FIXME: use main one until sandbox is working
           # ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
           ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         uses: zenodraft/action@0.10.0
-        #
-        # DISABLE THIS STEP CURRENTLY
-        #
-        if: false
         with:
           collection: 8387711
           metadata: .zenodo.json
@@ -126,8 +126,8 @@ jobs:
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -111,7 +111,7 @@ jobs:
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:
-          GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
+          GITHUB_TOKEN: PYPOP_RELEASE_TOKEN
 
   skip_publish_zenodo:
     name: Non publication, Zenodo skip

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -188,6 +188,9 @@ jobs:
        #     upsert-doi: true
        #     upsert-location: doi
        #     verbose: true
+       
+      # FIXME: this partially emulates the release updating that is
+      # internal to zenodraft
       - name: Get existing release
         id: get_existing_release
         uses: cardinalby/git-get-release-action@v1
@@ -208,9 +211,11 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           name: ${{ steps.get_existing_release.outputs.name }}
           body: ${{ steps.get_existing_release.outputs.body }}
-          #draft: ${{ steps.get_existing_release.outputs.draft }}
+          # FIXME: have to set these both to false, because not copied
+          # from the original release properly
+          # draft: ${{ steps.get_existing_release.outputs.draft }}
+          # prerelease: ${{ steps.get_existing_release.outputs.draft }}
           draft: false
-          #prerelease: ${{ steps.get_existing_release.outputs.draft }}
           prerelease: false
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -193,8 +193,8 @@ jobs:
         uses: cardinalby/git-get-release-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          with:
-            releaseId: ${{ github.event.release.id }}
+        with:
+          releaseId: ${{ github.event.release.id }}
       - name: Recreate release with new tag
         id: recreate_release
         uses: joutvhu/create-release@v1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -123,7 +123,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') }}
+    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') && always()  && !cancelled() && !failure() }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -111,7 +111,7 @@ jobs:
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:
-          GITHUB_TOKEN: PYPOP_RELEASE_TOKEN
+          GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
 
   skip_publish_zenodo:
     name: Non publication, Zenodo skip

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,8 @@ jobs:
     needs: [publish_zenodo, skip_publish_zenodo]
     # trying solution here: https://github.com/actions/runner/issues/491#issuecomment-1507495166
     # so that it works if either job in "needs" completes
-    if: always() && !cancelled() && !failure()
+    if: false()
+    #if: always() && !cancelled() && !failure()
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -42,6 +43,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
+          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.16.0
@@ -62,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:  # FIXME: use the refname, not the sha for published releases
+        with:  # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
           ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
 
       - name: Build sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -85,7 +85,7 @@ jobs:
           # ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         uses: zenodraft/action@0.10.0
         with:
-          collection: 1242414
+          # collection: 1242414
           metadata: .zenodo.json
           publish: false
           # FIXME: use main one until sandbox working

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,9 +43,8 @@ jobs:
     steps:
       - name: Checkout the contents of your repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PYPOP_RELEASE_TOKEN }}
-
+        # with:
+        #  token: ${{ secrets.PYPOP_RELEASE_TOKEN }}
       - name: Upsert the version in the metadata in .zenodo.json
         run: |
           echo "GITHUB_REF_NAME = $GITHUB_REF_NAME | GITHUB_REF = $GITHUB_REF | GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH"
@@ -129,8 +128,8 @@ jobs:
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -111,7 +111,7 @@ jobs:
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
 
   skip_publish_zenodo:
     name: Non publication, Zenodo skip

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -197,6 +197,8 @@ jobs:
           releaseId: ${{ github.event.release.id }}
       - name: Delete old release
         uses: liudonghua123/delete-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           release_id: ${{ github.event.release.id }}
       - name: Recreate release with new tag

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -39,7 +39,8 @@ jobs:
     name: Production release, Zenodo publication
     runs-on: ubuntu-latest
     # "else" we *are* publishing something
-    if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
+    # if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
+    if: false  # FIXME: disable until completely ready for a release
     steps:
       - name: Checkout the contents of your repository
         uses: actions/checkout@v4
@@ -96,8 +97,7 @@ jobs:
           upsert-location: doi
           verbose: true
       #
-      # FIXME: until zenodraft working, this partially emulates the
-      # release updating that is internal to zenodraft
+      # FIXME: disabled the rest of these steps (already done by zenodraft)
       #
       - name: Get existing release
         if: false

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,13 +1,13 @@
 name: Build PyPop
 
 on:
-  workflow_dispatch:  
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - '**.md'
       - '**.rst'
       - 'CITATION.cff'
-      - '.zenodo.json'      
+      - '.zenodo.json'
       - 'website/**'
       - '.github/workflows/documentation.yaml'
       - '.gitattributes'
@@ -16,12 +16,12 @@ on:
       - '**.md'
       - '**.rst'
       - 'CITATION.cff'
-      - '.zenodo.json'      
+      - '.zenodo.json'
       - 'website/**'
       - '.github/workflows/documentation.yaml'
-      - '.gitattributes'      
-  release: 
-     types: 
+      - '.gitattributes'
+  release:
+    types:
       - published
 
 jobs:
@@ -73,7 +73,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          path: dist/*.tar.gz 
+          path: dist/*.tar.gz
 
   upload_gh_release:
     name: Upload binary wheels and sdist to GH release page
@@ -134,40 +134,40 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-  
+
   publish_zenodo:
     name: Publish to zenodo on production releases only, otherwise no-op
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
     steps:
-       - name: Checkout the contents of your repository
-         uses: actions/checkout@v4
-       - name: Upsert the version in the metadata in .zenodo.json
-         run: |
-           echo "GITHUB_REF_NAME = $GITHUB_REF_NAME | GITHUB_REF = $GITHUB_REF | GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH"
-           echo "github.event.release.target_commitish = ${{ github.event.release.target_commitish }}"
-           cp .zenodo.json .zenodo.orig.json
-           echo "{\"version\": \"$GITHUB_REF_NAME\"}" | cat .zenodo.orig.json - | jq -s add > .zenodo.json
-           rm .zenodo.orig.json
-       - name: Upsert the version in the metadata in CITATION.cff
-         run: |
-           yq -i ".version = \"$GITHUB_REF_NAME\"" CITATION.cff
-       - name: Push changes back to repo files
-         run: |
-           git fetch origin
-           git config --global user.name ci
-           git config --global user.email "username@users.noreply.github.com"
-           git checkout -b $GITHUB_REF_NAME-with-upserting-changes
-           git add .zenodo.json CITATION.cff
-           git commit -m "Upserted version into CITATION.cff and into .zenodo.json"
-           git checkout ${{ github.event.release.target_commitish }}
-           git merge $GITHUB_REF_NAME-with-upserting-changes
-           git push origin ${{ github.event.release.target_commitish }}
-           git tag -d $GITHUB_REF_NAME
-           git push --follow-tags origin :$GITHUB_REF
-           git tag $GITHUB_REF_NAME
-           git push origin $GITHUB_REF
-           git ls-remote origin $GITHUB_REF
+      - name: Checkout the contents of your repository
+        uses: actions/checkout@v4
+      - name: Upsert the version in the metadata in .zenodo.json
+        run: |
+          echo "GITHUB_REF_NAME = $GITHUB_REF_NAME | GITHUB_REF = $GITHUB_REF | GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH"
+          echo "github.event.release.target_commitish = ${{ github.event.release.target_commitish }}"
+          cp .zenodo.json .zenodo.orig.json
+          echo "{\"version\": \"$GITHUB_REF_NAME\"}" | cat .zenodo.orig.json - | jq -s add > .zenodo.json
+          rm .zenodo.orig.json
+      - name: Upsert the version in the metadata in CITATION.cff
+        run: |
+          yq -i ".version = \"$GITHUB_REF_NAME\"" CITATION.cff
+      - name: Push changes back to repo files
+        run: |
+          git fetch origin
+          git config --global user.name ci
+          git config --global user.email "username@users.noreply.github.com"
+          git checkout -b $GITHUB_REF_NAME-with-upserting-changes
+          git add .zenodo.json CITATION.cff
+          git commit -m "Upserted version into CITATION.cff and into .zenodo.json"
+          git checkout ${{ github.event.release.target_commitish }}
+          git merge $GITHUB_REF_NAME-with-upserting-changes
+          git push origin ${{ github.event.release.target_commitish }}
+          git tag -d $GITHUB_REF_NAME
+          git push --follow-tags origin :$GITHUB_REF
+          git tag $GITHUB_REF_NAME
+          git push origin $GITHUB_REF
+          git ls-remote origin $GITHUB_REF
        # - name: Create a draft snapshot of your repository contents as a new
        #         version in test collection on Zenodo using metadata
        #         from repository file .zenodo.json
@@ -188,6 +188,26 @@ jobs:
        #     upsert-doi: true
        #     upsert-location: doi
        #     verbose: true
+      - name: Get existing release
+        id: get_existing_release
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          with:
+            releaseId: ${{ github.event.release.id }}
+      - name: Recreate release with new tag
+        id: recreate_release
+        uses: joutvhu/create-release@v1
+        with:
+          tag_name: $GITHUB_REF_NAME
+          name: ${{ steps.get_current_release.outputs.name }}
+          body: ${{ steps.get_current_release.outputs.body }}
+          draft: ${{ steps.get_current_release.outputs.draft }}
+          prerelease: ${{ steps.get_current_release.outputs.draft }}
+          target_commitish: ${{ steps.get_current_release.outputs.target_commitish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   skip_publish_zenodo:
     name: Skip Zenodo step unless publishing release
     runs-on: ubuntu-latest
@@ -198,8 +218,8 @@ jobs:
     steps:
       - name: Skip Zenodo step unless publishing release
         run: echo "Not a publication release, skipping Zenodo"
-        
-        
+
+
       # steps:
       #   # This step is not needed at the moment but might decide to add on more steps in the future
       #   - name: Set up Node.js

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,118 +25,9 @@ on:
       - published
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    # depend on zenodo, to make sure updated CITATION.cff gets into builds
-    # this only results in changes upon production releases
-    needs: [publish_zenodo, skip_publish_zenodo]
-    # trying solution here: https://github.com/actions/runner/issues/491#issuecomment-1507495166
-    # so that it works if either job in "needs" completes
-    if: false
-    #if: always() && !cancelled() && !failure()
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
-          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
-
-      - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.16.0
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
-  build_sdist:
-    name: Build source distribution
-    # depend on zenodo, to make sure updated CITATION.cff gets into builds
-    needs: [publish_zenodo, skip_publish_zenodo]
-    if: always() && !cancelled() && !failure()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:  # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
-          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
-
-      - name: Build sdist
-        run: pipx run build --sdist
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz
-
-  upload_gh_release:
-    name: Upload binary wheels and sdist to GH release page
-    #needs: [build_wheels, build_sdist]
-    needs: build_sdist
-    runs-on: ubuntu-latest
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    if: github.event_name == 'release' && github.event.action == 'published' && always() && !cancelled() && !failure()
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
-          path: dist
-      - uses: softprops/action-gh-release@v1
-        name: Uploading binaries to release page
-        with:
-          files: dist/*
-
-  upload_test_pypi:
-    name: Upload to Test_PyPI
-    #needs: [build_wheels, build_sdist]
-    needs: build_sdist
-    runs-on: ubuntu-latest
-    environment: test_pypi
-    permissions:
-      id-token: write
-    # drop requirement of 'main', release to test_pypi to test releases
-    if: github.event_name == 'release' && github.event.action == 'published' && always() && !cancelled() && !failure()
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
-          path: dist
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository_url: https://test.pypi.org/legacy/
-
-  upload_pypi:
-    name: Upload to PyPI
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') && always()  && !cancelled() && !failure() }}
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
-          path: dist
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish_zenodo:
-    name: Publish to zenodo on production releases only, otherwise no-op
+    publish_zenodo:
+    name: Production release: Zenodo publication
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
     steps:
@@ -223,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   skip_publish_zenodo:
-    name: Skip Zenodo step unless publishing release
+    name: Non publication: Zenodo skip
     runs-on: ubuntu-latest
     # "else" we aren't publishing anything, still need some event
     # do the logical inverse of the above "if" in publish_zenodo
@@ -232,6 +123,113 @@ jobs:
     steps:
       - name: Skip Zenodo step unless publishing release
         run: echo "Not a publication release, skipping Zenodo"
+  
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    # depend on zenodo, to make sure updated CITATION.cff gets into builds
+    # this only results in changes upon production releases
+    needs: [publish_zenodo, skip_publish_zenodo]
+    # trying solution here: https://github.com/actions/runner/issues/491#issuecomment-1507495166
+    # so that it works if either job in "needs" completes
+    if: always() && !cancelled() && !failure()
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11, windows-2019]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
+          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
+
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v2.16.0
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    # depend on zenodo, to make sure updated CITATION.cff gets into builds
+    needs: [publish_zenodo, skip_publish_zenodo]
+    if: always() && !cancelled() && !failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:  # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
+          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_gh_release:
+    name: Upload binary wheels and sdist to GH release page
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    if: github.event_name == 'release' && github.event.action == 'published' && always() && !cancelled() && !failure()
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+      - uses: softprops/action-gh-release@v1
+        name: Uploading binaries to release page
+        with:
+          files: dist/*
+
+  upload_test_pypi:
+    name: Upload to Test_PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: test_pypi
+    permissions:
+      id-token: write
+    # drop requirement of 'main', release to test_pypi to test releases
+    if: github.event_name == 'release' && github.event.action == 'published' && always() && !cancelled() && !failure()
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository_url: https://test.pypi.org/legacy/
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') && always()  && !cancelled() && !failure() }}
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
 
       # steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -77,10 +77,9 @@ jobs:
 
   upload_gh_release:
     name: Upload binary wheels and sdist to GH release page
-    needs: [build_wheels, build_sdist]
+    #needs: [build_wheels, build_sdist]
+    needs: build_sdist
     runs-on: ubuntu-latest
-    # upload to gh on every tag starting with 'v'
-    #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:  # FIXME: use the refname, not the sha for published releases
-          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || 'false' }}
+          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name ||  }}
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -85,7 +85,7 @@ jobs:
           # ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         uses: zenodraft/action@0.10.0
         with:
-          collection: 1243488
+          collection: 1242414
           metadata: .zenodo.json
           publish: false
           # FIXME: use main one until sandbox working

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -126,7 +126,8 @@ jobs:
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:
-          GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:  # FIXME: use the refname, not the sha for published releases
-          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || false }}
+          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || 'false' }}
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -200,11 +200,11 @@ jobs:
         uses: joutvhu/create-release@v1
         with:
           tag_name: $GITHUB_REF_NAME
-          name: ${{ steps.get_current_release.outputs.name }}
-          body: ${{ steps.get_current_release.outputs.body }}
-          draft: ${{ steps.get_current_release.outputs.draft }}
-          prerelease: ${{ steps.get_current_release.outputs.draft }}
-          target_commitish: ${{ steps.get_current_release.outputs.target_commitish }}
+          name: ${{ steps.get_existing_release.outputs.name }}
+          body: ${{ steps.get_existing_release.outputs.body }}
+          draft: ${{ steps.get_existing_release.outputs.draft }}
+          prerelease: ${{ steps.get_existing_release.outputs.draft }}
+          target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -195,6 +195,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           releaseId: ${{ github.event.release.id }}
+      - name: Delete old release
+        uses: liudonghua123/delete-release-action@v1
+        with:
+          release_id: ${{ github.event.release.id }}
       - name: Recreate release with new tag
         id: recreate_release
         uses: joutvhu/create-release@v1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -81,7 +81,7 @@ jobs:
     needs: build_sdist
     runs-on: ubuntu-latest
     # alternatively, to publish when a GitHub Release is created, use the following rule:
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published' && always() && !cancelled() && !failure()
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -101,7 +101,7 @@ jobs:
     environment: test_pypi
     permissions:
       id-token: write
-    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') }}
+    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') }} 
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -66,31 +66,31 @@ jobs:
           git checkout ${{ github.event.release.target_commitish }}
           git merge $GITHUB_REF_NAME-with-upserting-changes
           git push origin ${{ github.event.release.target_commitish }}
-          git tag -d $GITHUB_REF_NAME
-          git push --follow-tags origin :$GITHUB_REF
-          git tag $GITHUB_REF_NAME
-          git push origin $GITHUB_REF
-          git ls-remote origin $GITHUB_REF
+          # git tag -d $GITHUB_REF_NAME
+          # git push --follow-tags origin :$GITHUB_REF
+          # git tag $GITHUB_REF_NAME
+          # git push origin $GITHUB_REF
+          # git ls-remote origin $GITHUB_REF
       - name: Create a draft snapshot of your repository contents as a new
               version in test collection on Zenodo using metadata
               from repository file .zenodo.json
         #
         # DISABLE uploading via zenodraft action, currently
         #
-        if: false
+        # if: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # FIXME: use main one until sandbox is working
-          # ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-          ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+          # ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         uses: zenodraft/action@0.10.0
         with:
           collection: 8387711
           metadata: .zenodo.json
           publish: false
           # FIXME: use main one until sandbox working
-          # sandbox: true
-          sandbox: false
+          sandbox: true
+          # sandbox: false
           compression: tar.gz
           upsert-doi: true
           upsert-location: doi
@@ -100,6 +100,7 @@ jobs:
       # release updating that is internal to zenodraft
       #
       - name: Get existing release
+        if: false
         id: get_existing_release
         uses: cardinalby/git-get-release-action@v1
         env:
@@ -107,12 +108,14 @@ jobs:
         with:
           releaseId: ${{ github.event.release.id }}
       - name: Delete old release
+        if: false
         uses: liudonghua123/delete-release-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           release_id: ${{ github.event.release.id }}
       - name: Recreate release with new tag
+        if: false
         id: recreate_release
         uses: joutvhu/create-release@v1
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,11 +60,11 @@ jobs:
           git fetch origin
           git config --global user.name ci
           git config --global user.email "username@users.noreply.github.com"
-          git checkout -b $GITHUB_REF_NAME-with-upserting-changes
+          git checkout -b $GITHUB_REF_NAME-with-upserting-changes-pre-upload
           git add .zenodo.json CITATION.cff
           git commit -m "Upserted version into CITATION.cff and into .zenodo.json"
           git checkout ${{ github.event.release.target_commitish }}
-          git merge $GITHUB_REF_NAME-with-upserting-changes
+          git merge $GITHUB_REF_NAME-with-upserting-changes-pre-upload
           git push origin ${{ github.event.release.target_commitish }}
           # git tag -d $GITHUB_REF_NAME
           # git push --follow-tags origin :$GITHUB_REF
@@ -85,7 +85,7 @@ jobs:
           # ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         uses: zenodraft/action@0.10.0
         with:
-          # collection: 1242414
+          collection: 1244743
           metadata: .zenodo.json
           publish: false
           # FIXME: use main one until sandbox working

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,10 +25,20 @@ on:
       - published
 
 jobs:
+  skip_publish_zenodo:
+    name: Non publication, Zenodo skip
+    runs-on: ubuntu-latest
+    # FIXME: this is the default action, the logical inverse of the
+    # below "if" in publish_zenodo: a bit hacky, but it works
+    if: (github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false) == false
+    steps:
+      - name: Skip Zenodo step unless publishing release
+        run: echo "Not a publication release, skipping Zenodo"
 
   publish_zenodo:
     name: Production release, Zenodo publication
     runs-on: ubuntu-latest
+    # "else" we *are* publishing something
     if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
     steps:
       - name: Checkout the contents of your repository
@@ -59,29 +69,34 @@ jobs:
           git tag $GITHUB_REF_NAME
           git push origin $GITHUB_REF
           git ls-remote origin $GITHUB_REF
-       # - name: Create a draft snapshot of your repository contents as a new
-       #         version in test collection on Zenodo using metadata
-       #         from repository file .zenodo.json
-       #   env:
-       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       #     # FIXME: use main one until sandbox is working
-       #     # ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-       #     ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
-       #   uses: zenodraft/action@0.10.0
-       #   with:
-       #     collection: 8387711
-       #     metadata: .zenodo.json
-       #     publish: false
-       #     # FIXME: use main one until sandbox working
-       #     # sandbox: true
-       #     sandbox: false
-       #     compression: tar.gz
-       #     upsert-doi: true
-       #     upsert-location: doi
-       #     verbose: true
-
-      # FIXME: this partially emulates the release updating that is
-      # internal to zenodraft
+      - name: Create a draft snapshot of your repository contents as a new
+              version in test collection on Zenodo using metadata
+              from repository file .zenodo.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # FIXME: use main one until sandbox is working
+          # ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+          ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+        uses: zenodraft/action@0.10.0
+        #
+        # DISABLE THIS STEP CURRENTLY
+        #
+        if: false
+        with:
+          collection: 8387711
+          metadata: .zenodo.json
+          publish: false
+          # FIXME: use main one until sandbox working
+          # sandbox: true
+          sandbox: false
+          compression: tar.gz
+          upsert-doi: true
+          upsert-location: doi
+          verbose: true
+      #
+      # FIXME: until zenodraft working, this partially emulates the
+      # release updating that is internal to zenodraft
+      #
       - name: Get existing release
         id: get_existing_release
         uses: cardinalby/git-get-release-action@v1
@@ -113,17 +128,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PYPOP_RELEASE_TOKEN }}
 
-  skip_publish_zenodo:
-    name: Non publication, Zenodo skip
-    runs-on: ubuntu-latest
-    # "else" we aren't publishing anything, still need some event
-    # do the logical inverse of the above "if" in publish_zenodo
-    # FIXME: a bit hacky, but it works
-    if: (github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false) == false
-    steps:
-      - name: Skip Zenodo step unless publishing release
-        run: echo "Not a publication release, skipping Zenodo"
-
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     # depend on zenodo, to make sure updated CITATION.cff gets into builds
@@ -136,21 +140,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
           ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
-
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.16.0
         with:
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
-
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -165,10 +166,8 @@ jobs:
       - uses: actions/checkout@v4
         with:  # FIXME: if on a release, use the tag name, not original SHA because it might be changed (somewhat hacky)
           ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
-
       - name: Build sdist
         run: pipx run build --sdist
-
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
@@ -207,7 +206,6 @@ jobs:
           # if `name: artifact` is omitted, the action will create extra parent dir
           name: artifact
           path: dist
-
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository_url: https://test.pypi.org/legacy/
@@ -227,10 +225,8 @@ jobs:
           # if `name: artifact` is omitted, the action will create extra parent dir
           name: artifact
           path: dist
-
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-
 
       # steps:
       #   # This step is not needed at the moment but might decide to add on more steps in the future

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -208,8 +208,10 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           name: ${{ steps.get_existing_release.outputs.name }}
           body: ${{ steps.get_existing_release.outputs.body }}
-          draft: ${{ steps.get_existing_release.outputs.draft }}
-          prerelease: ${{ steps.get_existing_release.outputs.draft }}
+          #draft: ${{ steps.get_existing_release.outputs.draft }}
+          draft: false
+          #prerelease: ${{ steps.get_existing_release.outputs.draft }}
+          prerelease: false
           target_commitish: ${{ steps.get_existing_release.outputs.target_commitish }}
           on_release_exists: update
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
       - name: Checkout the contents of your repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PYPOP_RELEASE_TOKEN }}
+
       - name: Upsert the version in the metadata in .zenodo.json
         run: |
           echo "GITHUB_REF_NAME = $GITHUB_REF_NAME | GITHUB_REF = $GITHUB_REF | GITHUB_EVENT_PATH = $GITHUB_EVENT_PATH"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:  # FIXME: use the refname, not the sha for published releases
-          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name ||  }}
+          ref: ${{ (github.event_name == 'release' && github.event.action == 'published') && github.ref_name || '' }}
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -96,12 +96,14 @@ jobs:
 
   upload_test_pypi:
     name: Upload to Test_PyPI
-    needs: [build_wheels, build_sdist]
+    #needs: [build_wheels, build_sdist]
+    needs: build_sdist
     runs-on: ubuntu-latest
     environment: test_pypi
     permissions:
       id-token: write
-    if: ${{ (github.ref == 'refs/heads/main') && (github.event_name == 'release' && github.event.action == 'published') }} 
+    # drop requirement of 'main', release to test_pypi to test releases
+    if: github.event_name == 'release' && github.event.action == 'published' && always() && !cancelled() && !failure()
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -85,7 +85,7 @@ jobs:
           # ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
         uses: zenodraft/action@0.10.0
         with:
-          collection: 8387711
+          collection: 1243488
           metadata: .zenodo.json
           publish: false
           # FIXME: use main one until sandbox working

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [publish_zenodo, skip_publish_zenodo]
     # trying solution here: https://github.com/actions/runner/issues/491#issuecomment-1507495166
     # so that it works if either job in "needs" completes
-    if: false()
+    if: false
     #if: always() && !cancelled() && !failure()
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,8 +26,8 @@ on:
 
 jobs:
 
-    publish_zenodo:
-    name: Production release: Zenodo publication
+  publish_zenodo:
+    name: Production release, Zenodo publication
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease == false
     steps:
@@ -79,7 +79,7 @@ jobs:
        #     upsert-doi: true
        #     upsert-location: doi
        #     verbose: true
-       
+
       # FIXME: this partially emulates the release updating that is
       # internal to zenodraft
       - name: Get existing release
@@ -114,7 +114,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   skip_publish_zenodo:
-    name: Non publication: Zenodo skip
+    name: Non publication, Zenodo skip
     runs-on: ubuntu-latest
     # "else" we aren't publishing anything, still need some event
     # do the logical inverse of the above "if" in publish_zenodo
@@ -123,7 +123,7 @@ jobs:
     steps:
       - name: Skip Zenodo step unless publishing release
         run: echo "Not a publication release, skipping Zenodo"
-  
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     # depend on zenodo, to make sure updated CITATION.cff gets into builds

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.65"
+  "version": "v0.9.66"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.57"
+  "version": "v0.9.58"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.68"
+  "version": "v0.9.69"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.45"
+  "version": "v0.9.46"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.46"
+  "version": "v0.9.47"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.69"
+  "version": "v0.9.70"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.54"
+  "version": "v0.9.55"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.74"
+  "version": "v0.9.75"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.60"
+  "version": "v0.9.61"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.44"
+  "version": "v0.9.45"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.75"
+  "version": "v1.0.0-b1"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.62"
+  "version": "v0.9.63"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.53"
+  "version": "v0.9.54"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.66"
+  "version": "v0.9.67"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.71"
+  "version": "v0.9.73"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.64"
+  "version": "v0.9.65"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.47"
+  "version": "v0.9.48"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.58"
+  "version": "v0.9.60"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.61"
+  "version": "v0.9.62"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.67"
+  "version": "v0.9.68"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -76,5 +76,5 @@
   },
   "title": "PyPop: Python for Population Genomics",
   "upload_type": "software",
-  "version": "v0.9.56"
+  "version": "v0.9.57"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.45
+version: v0.9.46
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.47
+version: v0.9.48
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.65
+version: v0.9.66
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.56
+version: v0.9.57
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -74,5 +74,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.75
-doi: 10.5072/zenodo.1244745
+version: v1.0.0-b1
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.46
+version: v0.9.47
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.71
+version: v0.9.73
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.66
+version: v0.9.67
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.58
+version: v0.9.60
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.69
+version: v0.9.70
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.44
+version: v0.9.45
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,16 @@
 cff-version: 1.2.0
 message: >-
-  If you use this software, please cite both the software itself, as well as the the article Lancaster AK et al. (2007) 'PyPop update – a software pipeline for large-scale multilocus population genomics' Tissue Antigens 69(1):192-197 10.1111/j.1399-0039.2006.00769.x https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4369784/
+  If you use this software, please cite both the software itself, as well as the
+  the article Lancaster AK et al. (2007) 'PyPop update – a software pipeline for
+  large-scale multilocus population genomics' Tissue Antigens 69(1):192-197
+  10.1111/j.1399-0039.2006.00769.x
+  https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4369784/
 abstract: >-
-  PyPop for Population Genomics (PyPop) is a Python program for processing genotype and allele data and running population genetic analyses, including conformity to Hardy-Weinberg expectations; tests for balancing or directional selection; estimates of haplotype frequencies and measures and tests of significance for linkage disequilibrium (LD). Main website: http://pypop.org/
+  PyPop for Population Genomics (PyPop) is a Python program for processing
+  genotype and allele data and running population genetic analyses, including
+  conformity to Hardy-Weinberg expectations; tests for balancing or directional
+  selection; estimates of haplotype frequencies and measures and tests of
+  significance for linkage disequilibrium (LD). Main website: http://pypop.org/
 authors:
   - family-names: Lancaster
     given-names: Alexander K.
@@ -67,4 +75,4 @@ keywords:
   - MHC
 license: GPL-2.0-or-later
 version: v0.9.75
-doi: 10.5281/zenodo.8384146
+doi: 10.5072/zenodo.1244745

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.54
+version: v0.9.55
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.62
+version: v0.9.63
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.60
+version: v0.9.61
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.68
+version: v0.9.69
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.53
+version: v0.9.54
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.61
+version: v0.9.62
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.64
+version: v0.9.65
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.67
+version: v0.9.68
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.57
+version: v0.9.58
 doi: 10.5281/zenodo.8384146

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -66,5 +66,5 @@ keywords:
   - HLA
   - MHC
 license: GPL-2.0-or-later
-version: v0.9.74
+version: v0.9.75
 doi: 10.5281/zenodo.8384146

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,9 @@ User Guide <http://pypop.org/docs>`__ for a more detailed description.
 		       
 **How to cite PyPop**
 
-If you write a paper that uses PyPop in your analysis, please cite
-**both**:
+If you write a paper that uses PyPop in your analysis, please cite:
 
-1. our 2007 paper from *Tissue Antigens*:
+* our 2007 paper from *Tissue Antigens*:
 
    .. admonition:: *Tissue Antigens*
    
@@ -29,22 +28,23 @@ If you write a paper that uses PyPop in your analysis, please cite
       `preprint PDF (112 kB)
       <http://pypop.org/tissue-antigens-lancaster-2007.pdf>`__].
 
-2. **and** the Zenodo record for the specific version of the software
-   (which has a version-specific DOI).  First visit the main `Zenodo
-   record <https://doi.org/10.5072/zenodo.1243488>`__ and use the DOI
-   of the specific version of the software you used.  It will be of
-   the form:
+..
+   2. **and** the Zenodo record for the specific version of the software
+      (which has a version-specific DOI).  First visit the main `Zenodo
+      record <https://doi.org/10.5072/zenodo.1243488>`__ and use the DOI
+      of the specific version of the software you used.  It will be of
+      the form:
 
-   .. admonition:: Zenodo
+      .. admonition:: Zenodo
 
-      Lancaster, AK et al. (2023) "PyPop: Python for Population
-      Genomics" (Version 1.0.0) [Computer
-      software]. https://doi.org/10.5281/zenodo.XXXXX
+	 Lancaster, AK et al. (2023) "PyPop: Python for Population
+	 Genomics" (Version 1.0.0) [Computer
+	 software]. https://doi.org/10.5281/zenodo.XXXXX
 
-   Human and machine-readable citation metadata for the Zenodo record
-   is stored in the `CITATION.cff
-   <https://github.com/alexlancaster/pypop/blob/main/CITATION.cff>`__
-   in the GitHub repository.
+      Human and machine-readable citation metadata for the Zenodo record
+      is stored in the `CITATION.cff
+      <https://github.com/alexlancaster/pypop/blob/main/CITATION.cff>`__
+      in the GitHub repository.
   
 .. _guide-include-pypop-cite-end:
 


### PR DESCRIPTION
* adds infrastructure for:
  * bumping versions in `CITATION.cff` and `.zenodo.json` from release tag in GitHub release UI
  * getting provisional DOI from Zenodo sandbox
  * updating the DOI in `CITATION.cff`
  * uploading to the Zenodo sandbox
  * retagging the version to include the changes that were uploaded

* makes sure all builds and releases, and PyPI releases are now:
  * downstream of the above so they include all the committed changes
  * enable skipping of the retagging on non-Zenodo release