### PR TITLE
Enable MacOS Apple Silicon builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*"]  # skip certain builds, including 32-bit, musllinux and others
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
+# Skip trying to test arm64 builds on Intel Macs as per
+# https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
+test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 
 [tool.cibuildwheel.linux]
 # for CentOS-based runners, local cibuildwheel docker
@@ -13,6 +16,9 @@ before-all="yum install -y swig gsl-devel"
 before-all = "brew install swig gsl"
 # FIXME: on MacOS, cibuildwheel team suggests building these from
 # source within the container, rather than using 'brew'
+
+# support cross-compilation on Apple Silicon
+archs = ["x86_64", "universal2", "arm64"]  
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ before-all = "brew install swig gsl"
 # source within the container, rather than using 'brew'
 
 # support cross-compilation on Apple Silicon
-archs = ["x86_64", "universal2", "arm64"]  
+archs = ["x86_64", "arm64"]  
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths


### PR DESCRIPTION
They require special enabling in `pyproject.toml`.  Thanks to @odoublewen for the report.