### PR TITLE
Fix arm64 cross-compilation on MacOS

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -155,7 +155,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        #os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [macos-11]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -155,8 +155,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-20.04, macos-11, windows-2019]
-        os: [macos-11]
+        os: [ubuntu-20.04, macos-11, windows-2019]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per
 # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-#test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 
 [tool.cibuildwheel.linux]
 # for CentOS-based runners, local cibuildwheel docker
@@ -18,8 +18,12 @@ before-all="yum install -y swig gsl-devel"
 # FIXME: on MacOS, cibuildwheel team suggests building these from
 # source within the container, rather than using 'brew'
 # SWIG is already present
-# install gsl for each environment
+# force correct architecture on cross-compilations (https://stackoverflow.com/a/75488269)
 before-build = [
+  "echo pwd= $(pwd)",
+  "echo wheel = {wheel}",
+  "echo dest_dir = {dest_dir}",
+  "echo delocate_wheel = {delocate_wheel}",  
   "brew fetch --force --bottle-tag=arm64_big_sur gsl",
   "brew install $(brew --cache --bottle-tag=arm64_big_sur gsl)"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.cibuildwheel]
-skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*",
-       "pp*"]  # skip certain builds, including 32-bit, musllinux and others
+skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*"]  # skip certain builds, including 32-bit, musllinux and others
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per
@@ -14,20 +13,16 @@ before-all="yum install -y swig gsl-devel"
 #before-all="apt install swig libgsl-dev"
 
 [tool.cibuildwheel.macos]
-# FIXME: SWIG is already present, no 'brew' installation neeeded
-
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = [
   "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
   "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew install $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew install gsl; fi"
  ]
+# note that SWIG is already present on runners, no 'brew' installation neeeded
 
 # support cross-compilation on Apple Silicon
 archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
-
-# Increase pip debugging output
-build-verbosity = 2
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,20 +20,16 @@ before-all="yum install -y swig gsl-devel"
 # SWIG is already present
 # force correct architecture on cross-compilations (https://stackoverflow.com/a/75488269)
 before-build = [
-  "echo _PYTHON_HOST_PLATFORM = $_PYTHON_HOST_PLATFORM",
-  "echo ARCHFLAGS = $ARCHFLAGS",
-  "echo ARCH = $ARCH",  
-  "echo arch = ${ARCHFLAGS:5:6}",  # gets the arch at build-time
+  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
   "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew install $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew install gsl; fi"
  ]
 
 # support cross-compilation on Apple Silicon
-archs = ["arm64"] #, "x86_64"]
+archs = ["arm64", "x86_64"]
 #archs = ["universal2"]
 
 # Increase pip debugging output
 build-verbosity = 2
-
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ before-all = "brew install swig gsl"
 # source within the container, rather than using 'brew'
 
 # support cross-compilation on Apple Silicon
-#archs = ["x86_64", "arm64"]
-archs = ["universal2"]
+archs = ["x86_64", "arm64"]
+#archs = ["universal2"]
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*",
-       "cp38*", "cp39*", "cp311*", "cp312", "pp*", "*win*", "*linux*"]  # skip certain builds, including 32-bit, musllinux and others
+       "cp36*", "cp37*", "cp38*", "cp39*", "cp311*", "cp312", "pp*", "*win*", "*linux*"]  # skip certain builds, including 32-bit, musllinux and others
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per
 # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+#test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 
 [tool.cibuildwheel.linux]
 # for CentOS-based runners, local cibuildwheel docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,10 @@ before-all="yum install -y swig gsl-devel"
 before-build = [
   "echo _PYTHON_HOST_PLATFORM = $_PYTHON_HOST_PLATFORM",
   "echo ARCHFLAGS = $ARCHFLAGS",
-  "echo SDKROOT = $SDKROOT",
-  "echo pwd = $(pwd)",
-  "echo wheel = {wheel}",
-  "echo dest_dir = {dest_dir}",
-  "echo delocate_wheel = {delocate_wheel}",  
-  "brew fetch --force --bottle-tag=arm64_big_sur gsl",
-  "brew install $(brew --cache --bottle-tag=arm64_big_sur gsl)"]
+  "echo ARCH = $ARCH",  
+  "echo arch = ${ARCHFLAGS:5:6}",  # gets the arch at build-time
+  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew install $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew install gsl; fi"
+ ]
 
 # support cross-compilation on Apple Silicon
 archs = ["arm64"] #, "x86_64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,15 @@ before-all="yum install -y swig gsl-devel"
 #before-all="apt install swig libgsl-dev"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install swig gsl"
+# before-all = "brew install swig gsl"
 # FIXME: on MacOS, cibuildwheel team suggests building these from
 # source within the container, rather than using 'brew'
+# SWIG is already present
+# install gsl for each environment
+before-build = "brew install gsl"
 
 # support cross-compilation on Apple Silicon
-archs = ["arm64", "x86_64"]
+archs = ["arm64"] #, "x86_64"]
 #archs = ["universal2"]
 
 # Increase pip debugging output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*",
-       "cp36*", "cp37*", "cp38*", "cp39*", "cp311*", "cp312*", "pp*", "*win*", "*linux*"]  # skip certain builds, including 32-bit, musllinux and others
+       "pp*"]  # skip certain builds, including 32-bit, musllinux and others
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*",
-       "cp36*", "cp37*", "cp38*", "cp39*", "cp311*", "cp312", "pp*", "*win*", "*linux*"]  # skip certain builds, including 32-bit, musllinux and others
+       "cp36*", "cp37*", "cp38*", "cp39*", "cp311*", "cp312*", "pp*", "*win*", "*linux*"]  # skip certain builds, including 32-bit, musllinux and others
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per
@@ -19,8 +19,12 @@ before-all = "brew install swig gsl"
 # source within the container, rather than using 'brew'
 
 # support cross-compilation on Apple Silicon
-archs = ["x86_64", "arm64"]
+archs = ["arm64", "x86_64"]
 #archs = ["universal2"]
+
+# Increase pip debugging output
+build-verbosity = 2
+
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,19 +14,17 @@ before-all="yum install -y swig gsl-devel"
 #before-all="apt install swig libgsl-dev"
 
 [tool.cibuildwheel.macos]
-# before-all = "brew install swig gsl"
-# FIXME: on MacOS, cibuildwheel team suggests building these from
-# source within the container, rather than using 'brew'
-# SWIG is already present
-# force correct architecture on cross-compilations (https://stackoverflow.com/a/75488269)
+# FIXME: SWIG is already present, no 'brew' installation neeeded
+
+# do a per-build 'gsl' installation to force correct architecture when
+# cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = [
   "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
   "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew install $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew install gsl; fi"
  ]
 
 # support cross-compilation on Apple Silicon
-archs = ["arm64", "x86_64"]
-#archs = ["universal2"]
+archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 
 # Increase pip debugging output
 build-verbosity = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ before-all="yum install -y swig gsl-devel"
 # source within the container, rather than using 'brew'
 # SWIG is already present
 # install gsl for each environment
-before-build = "brew install gsl"
+before-build = [
+  "brew fetch --force --bottle-tag=arm64_big_sur gsl",
+  "brew install $(brew --cache --bottle-tag=arm64_big_sur gsl)"]
 
 # support cross-compilation on Apple Silicon
 archs = ["arm64"] #, "x86_64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ before-all="yum install -y swig gsl-devel"
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = [
   "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
-  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew install $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew install gsl; fi"
+  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew reinstall gsl; fi"
  ]
 # note that SWIG is already present on runners, no 'brew' installation neeeded
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.cibuildwheel]
-skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*"]  # skip certain builds, including 32-bit, musllinux and others
+skip = ["*-win32", "*_i686", "*-musllinux_*", "pp37-win_*", "pp310*", "cp312-*linux*",
+       "cp38*", "cp39*", "cp311*", "cp312", "pp*", "*win*", "*linux*"]  # skip certain builds, including 32-bit, musllinux and others
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests"
 # Skip trying to test arm64 builds on Intel Macs as per
@@ -18,7 +19,8 @@ before-all = "brew install swig gsl"
 # source within the container, rather than using 'brew'
 
 # support cross-compilation on Apple Silicon
-archs = ["x86_64", "arm64"]  
+#archs = ["x86_64", "arm64"]
+archs = ["universal2"]
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ before-all="yum install -y swig gsl-devel"
 # SWIG is already present
 # force correct architecture on cross-compilations (https://stackoverflow.com/a/75488269)
 before-build = [
-  "echo pwd= $(pwd)",
+  "echo _PYTHON_HOST_PLATFORM = $_PYTHON_HOST_PLATFORM",
+  "echo ARCHFLAGS = $ARCHFLAGS",
+  "echo SDKROOT = $SDKROOT",
+  "echo pwd = $(pwd)",
   "echo wheel = {wheel}",
   "echo dest_dir = {dest_dir}",
   "echo delocate_wheel = {delocate_wheel}",  


### PR DESCRIPTION
needed to explicitly install the arm64 version of `gsl` via `brew` when building arm so that binary dependencies are packaged.