### PR TITLE
remove `psutil` - only used by a currently skipped unit test

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -529,13 +529,13 @@ Build-and-run-from-checkout (recommended for developers)
 
       .. code-block:: shell
 
-         pip install numpy lxml psutil pytest setuptools_scm
+         pip install numpy lxml pytest setuptools_scm
 
    2. system-wide
 
       .. code-block:: shell
 
-         pip install --user numpy lxml psutil pytest setuptools_scm
+         pip install --user numpy lxml pytest setuptools_scm
 
 2. Run the build
 

--- a/setup.py
+++ b/setup.py
@@ -250,10 +250,11 @@ setup (name = __pkgname__,
        package_dir = {"": src_dir},
        packages = ["PyPop", "PyPop.xslt"],
        package_data={"PyPop.xslt": data_file_paths},
-       install_requires = ["numpy <= 1.25.2; python_version <= '3.11'", "numpy >= 1.26b1; python_version > '3.11'", "lxml <= 4.9.3", "psutil <= 5.9.5",
+       install_requires = ["numpy <= 1.25.2; python_version <= '3.11'", "numpy >= 1.26b1; python_version > '3.11'", "lxml <= 4.9.3",
                            "importlib-resources; python_version <= '3.8'", "importlib-metadata; python_version <= '3.8'"],
        extras_require={
            "test": ['pytest']
+           # FIXME:  "psutil <= 5.9.5", not currently used, 5.9.6 and later had problems with building on Windows PyPy
            },
        entry_points = {
            'console_scripts': ['pypop=PyPop.pypop:main',

--- a/tests/test_100k_Emhaplofreq.py
+++ b/tests/test_100k_Emhaplofreq.py
@@ -1,7 +1,8 @@
 import subprocess
 import hashlib
 import pytest
-import psutil
+# FIXME: psutil currently not used, unit test disabled
+# import psutil
 from base import run_pypop_process
 
 memory_in_gb = 2  # memory needed for this test in GB


### PR DESCRIPTION
can restore at a later date if needed, currently cluttering up `install_requires` since it doesn't always have wheels for certain platforms like Windows