### PR TITLE
Enable native MacOS Apple Silicon runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -141,7 +141,7 @@ jobs:
               | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
               && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "macos-11"}' \
-              && cibuildwheel --print-build-identifiers --platform macos -archs arm64 \
+              && cibuildwheel --print-build-identifiers --platform macos --archs arm64 \
               | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows \
               | jq -nRc '{"only": inputs, "os": "windows-2019"}'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -137,9 +137,7 @@ jobs:
           else
             MATRIX=$(
               {
-              echo '{"only": "pp38-macosx_arm64", "os": "macos-14"}' \
-              && echo '{"only": "pp39-macosx_arm64", "os": "macos-14"}' \
-              && cibuildwheel --print-build-identifiers --platform linux \
+              cibuildwheel --print-build-identifiers --platform linux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
               && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "macos-11"}' \

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -137,7 +137,9 @@ jobs:
           else
             MATRIX=$(
               {
-              cibuildwheel --print-build-identifiers --platform linux \
+              echo '{"only": "pp38-macosx_arm64", "os": "macos-14"}' \
+              && echo '{"only": "pp39-macosx_arm64", "os": "macos-14"}' \
+              && cibuildwheel --print-build-identifiers --platform linux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
               && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "macos-11"}' \

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -139,9 +139,9 @@ jobs:
               {
               cibuildwheel --print-build-identifiers --platform linux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
-              && cibuildwheel --print-build-identifiers --platform macos \
+              && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 \
               | jq -nRc '{"only": inputs, "os": "macos-11"}' \
-              && cibuildwheel --print-build-identifiers --platform macos \
+              && cibuildwheel --print-build-identifiers --platform macos -archs arm64 \
               | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows \
               | jq -nRc '{"only": inputs, "os": "windows-2019"}'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           echo "CI_ONLY" $CI_ONLY
           if [ "$CI_ONLY" == "true" ]; then
-            MATRIX="[{'only':'cp312-manylinux_x86_64','os':'ubuntu-20.04'},{'only':'cp312-win_amd64','os':'windows-2019'}, {'only':'cp312-macosx_x86_64','os':'macos-11'}, {'only':'cp312-macosx_arm64','os':'macos-11'}]"
+            MATRIX="[{'only':'cp312-manylinux_x86_64','os':'ubuntu-20.04'},{'only':'cp312-win_amd64','os':'windows-2019'}, {'only':'cp312-macosx_x86_64','os':'macos-11'}, {'only':'cp312-macosx_arm64','os':'macos-14'}]"
           else
             MATRIX=$(
               {
@@ -141,6 +141,8 @@ jobs:
               | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
               && cibuildwheel --print-build-identifiers --platform macos \
               | jq -nRc '{"only": inputs, "os": "macos-11"}' \
+              && cibuildwheel --print-build-identifiers --platform macos \
+              | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows \
               | jq -nRc '{"only": inputs, "os": "windows-2019"}'
             } | jq -sc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ before-all = "apk add swig gsl-dev"
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = "brew install swig gsl"
-environment = { CPATH="/opt/homebrew/Cellar" }
+environment = { CPATH="/opt/homebrew/include" }
 
 # before-build = [
 #  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ before-all="yum install -y swig gsl-devel"
 select = "*musllinux*"
 before-all = "apk add swig gsl-dev"
 
-#[tool.cibuildwheel.macos]
+[tool.cibuildwheel.macos]
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = "brew install swig gsl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,9 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" 
 #  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew reinstall gsl; fi"
 # ]
 # note that SWIG is already present on runners, no 'brew' installation neeeded
-
 # support cross-compilation on Apple Silicon
-#archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
+
+archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ before-all = "apk add swig gsl-dev"
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = "brew install swig gsl"
+environment = { CPATH="/opt/homebrew/Cellar" }
 
 # before-build = [
 #  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ test-command = "pytest -v {package}/tests"
 
 # Skip trying to test arm64 builds on Intel Macs as per
 # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
+# test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 # don't try and install pypi packages and build from source
 environment = { PIP_ONLY_BINARY=":all:" }
 
@@ -47,17 +47,17 @@ before-all="yum install -y swig gsl-devel"
 select = "*musllinux*"
 before-all = "apk add swig gsl-dev"
 
-[tool.cibuildwheel.macos]
+#[tool.cibuildwheel.macos]
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
-before-build = [
-  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
-  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew reinstall gsl; fi"
- ]
+# before-build = [
+#  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
+#  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew reinstall gsl; fi"
+# ]
 # note that SWIG is already present on runners, no 'brew' installation neeeded
 
 # support cross-compilation on Apple Silicon
-archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
+#archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ before-all = "apk add swig gsl-dev"
 #[tool.cibuildwheel.macos]
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
+before-build = "brew install swig gsl"
+
 # before-build = [
 #  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
 #  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew reinstall gsl; fi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ before-all = "apk add swig gsl-dev"
 [tool.cibuildwheel.macos]
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
-before-build = "brew install swig gsl"
+before-all = "brew install swig gsl"
+inherit.environment="append"
 environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
 
 # before-build = [
@@ -65,8 +66,9 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths
 before-all = "nuget install gsl-msvc14-x64 -Version 2.3.0.2779"
-# note that we have to repeat the global PIP_ONLY_BINARY config, because this variables overwrites previous defines
-environment = { CPATH="gsl-msvc14-x64.2.3.0.2779\\\\build\\\\native", LIBRARY_PATH="gsl-msvc14-x64.2.3.0.2779\\\\build\\\\native\\\\static", PIP_ONLY_BINARY=":all:" }
+# no need to repeat the global PIP_ONLY_BINARY config, it is inherited from earlier config
+inherit.environment="append"
+environment = { CPATH="gsl-msvc14-x64.2.3.0.2779\\\\build\\\\native", LIBRARY_PATH="gsl-msvc14-x64.2.3.0.2779\\\\build\\\\native\\\\static" }
 
 [build-system]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ before-all = "apk add swig gsl-dev"
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-build = "brew install swig gsl"
-environment = { CPATH="/opt/homebrew/include" }
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
 
 # before-build = [
 #  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,22 +51,25 @@ before-all = "apk add swig gsl-dev"
 # do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 before-all = "brew install swig gsl"
-inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
-
 # before-build = [
 #  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
 #  "if [[ $ARCHFLAGS == *arm64 ]]; then brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl); else brew reinstall gsl; fi"
 # ]
 # note that SWIG is already present on runners, no 'brew' installation neeeded
 # support cross-compilation on Apple Silicon
-
 archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_*"
+inherit.environment="append"
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths
 before-all = "nuget install gsl-msvc14-x64 -Version 2.3.0.2779"
-# no need to repeat the global PIP_ONLY_BINARY config, it is inherited from earlier config
+
+[[tool.cibuildwheel.overrides]]
+select ="*-win_*"
 inherit.environment="append"
 environment = { CPATH="gsl-msvc14-x64.2.3.0.2779\\\\build\\\\native", LIBRARY_PATH="gsl-msvc14-x64.2.3.0.2779\\\\build\\\\native\\\\static" }
 


### PR DESCRIPTION
* simplify workflow: use inheritance to make sure global environment variables are consistently set

* drop cross-compilation for all MacOS arm64 builds

* re-enable unit tests for MacOS arm64