### PR TITLE
Pin `gsl` bottles to 2.7.1 on macOS to preserve 10.15/Catalina on x86 and 11.0/Big Sur compatibility

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
         # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.19.1
+        run: pipx install cibuildwheel==2.19.2
       - id: set-matrix
         run: |
           echo "CI_ONLY" $CI_ONLY
@@ -180,7 +180,7 @@ jobs:
         with:
           platforms: all          
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           # FIXME: only run the slow tests when doing regular pushes, or manual - not for PRs
           CIBW_TEST_COMMAND: "pytest -v {package}/tests ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && '--runslow' || '' }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ select = "*-macosx_arm64"
 inherit.before-all="append"
 # need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
 
-before-all = "brew install --build-from-source"
+before-all = "brew install --build-from-source gsl"
 #before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,8 @@ environment = { PIP_ONLY_BINARY=":all:" }
 
 [[tool.cibuildwheel.overrides]]
 # for latest CPython use newer manylinux image
-select = "cp*-*linux*"
+select = "cp312-*linux*"
 manylinux-x86_64-image = "manylinux_2_28"
-manylinux-aarch64-image = "manylinux_2_28"
 
 [[tool.cibuildwheel.overrides]]
 # for latest PyPy use newer manylinux image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ select = "*-macosx_arm64"
 inherit.before-all="append"
 # need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
 
-before-all: "brew install --build-from-source"
+before-all = "brew install --build-from-source"
 #before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,21 +63,22 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
-
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_x86_64"
-inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # 10.15 is Catalina the minimum version of gsl supported by 'brew' 
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", MACOSX_DEPLOYMENT_TARGET="12" } # 12 / Monterey the minimum version of gsl supported by 'brew'
 inherit.before-all="append"
-# install the catalina version of `gsl` to match
-before-all = "brew fetch --force --bottle-tag=catalina gsl; brew reinstall $(brew --cache --bottle-tag=catalina gsl)"
+before-all = "brew install gsl"
 
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_arm64"
-inherit.before-all="append"
-# need to force the Big Sur (MacOS 11.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
-before-all = "brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl)"
+# [[tool.cibuildwheel.overrides]]
+# select = "*-macosx_x86_64"
+# inherit.environment="append"
+# inherit.before-all="append"
+# # install the catalina version of `gsl` to match
+# before-all = "brew fetch --force --bottle-tag=catalina gsl; brew reinstall $(brew --cache --bottle-tag=catalina gsl)"
+
+# [[tool.cibuildwheel.overrides]]
+# select = "*-macosx_arm64"
+# inherit.before-all="append"
+# # need to force the Big Sur (MacOS 11.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
+#before-all = "brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl)"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ environment = { PIP_ONLY_BINARY=":all:" }
 # for latest CPython use newer manylinux image
 select = "cp*-*linux*"
 manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 [[tool.cibuildwheel.overrides]]
 # for latest PyPy use newer manylinux image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ before-all = "apk add swig gsl-dev"
 musllinux-x86_64-image="musllinux_1_1"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install swig"
+before-all = ["brew install swig oras",
+	      "oras ghcr.io/homebrew/core/gsl:2.7.1"]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [
@@ -63,25 +64,22 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-# 12 / Monterey the minimum version of gsl supported by 'brew'
 environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib"}
 #, MACOSX_DEPLOYMENT_TARGET="12.0" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.9" } # target 10.9 for brew rebuild
+environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15 for brew rebuild
 inherit.before-all="append"
-before-all = "brew install --build-from-source gsl"
+before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"]
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0 for brew rebuild
 inherit.before-all="append"
-# need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
-
-before-all = "brew install --build-from-source gsl"
+before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
 #before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,12 +63,11 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", MACOSX_DEPLOYMENT_TARGET="12.0" }
+# 12 / Monterey the minimum version of gsl supported by 'brew'
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
-inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # 12 / Monterey the minimum version of gsl supported by 'brew'
 inherit.before-all="append"
 before-all = "brew install gsl"
 # # install the catalina version of `gsl` to match

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ musllinux-x86_64-image="musllinux_1_1"
 
 [tool.cibuildwheel.macos]
 before-all = ["brew install swig oras",
-	      "oras ghcr.io/homebrew/core/gsl:2.7.1"]
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,18 +64,21 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 select = "*-macosx_*"
 inherit.environment="append"
 # 12 / Monterey the minimum version of gsl supported by 'brew'
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", MACOSX_DEPLOYMENT_TARGET="12.0" }
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib"}
+#, MACOSX_DEPLOYMENT_TARGET="12.0" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.before-all="append"
-before-all = "brew install gsl"
+before-all = "brew install --build-from-source gsl"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.before-all="append"
 # need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
-before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
+
+before-all: "brew install --build-from-source"
+#before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]
 select = "cp3[67]*-macosx_x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ select = "*-macosx_x86_64"
 inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15 for brew rebuild
 inherit.before-all="append"
-before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"]
+before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,9 @@ before-all = "apk add swig gsl-dev"
 musllinux-x86_64-image="musllinux_1_1"
 
 [tool.cibuildwheel.macos]
+# use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install swig oras",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"]
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"] 
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [
@@ -65,13 +66,14 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib"}
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15/Catalina
 inherit.before-all="append"
+# install the catalina version of `gsl` to match
 before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
 
 [[tool.cibuildwheel.overrides]]
@@ -79,6 +81,7 @@ select = "*-macosx_arm64"
 inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
+# install the Big Sur version of `gsl` to match
 before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ environment = { PIP_ONLY_BINARY=":all:" }
 
 [[tool.cibuildwheel.overrides]]
 # for latest CPython use newer manylinux image
-select = "cp-*linux*"
+select = "cp*-*linux*"
 manylinux-x86_64-image = "manylinux_2_28"
 
 [[tool.cibuildwheel.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,15 +63,13 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", MACOSX_DEPLOYMENT_TARGET="12.0" }
 # 12 / Monterey the minimum version of gsl supported by 'brew'
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", MACOSX_DEPLOYMENT_TARGET="12.0" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.before-all="append"
 before-all = "brew install gsl"
-# # install the catalina version of `gsl` to match
-# before-all = "brew fetch --force --bottle-tag=catalina gsl; brew reinstall $(brew --cache --bottle-tag=catalina gsl)"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,33 +59,27 @@ before-all = ["brew install swig oras",
 #  "if [[ $ARCHFLAGS == *arm64 ]]; then BOTTLE_TAG=arm64_big_sur gsl; else BOTTLE_TAG=x86_64_linux; fi",
 #  "echo BOTTLE_TAG = $BOTTLE_TAG",
 #]
+# force old bottle brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
 environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib"}
-#, MACOSX_DEPLOYMENT_TARGET="12.0" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15 for brew rebuild
+environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15/Catalina
 inherit.before-all="append"
 before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0 for brew rebuild
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
-#before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
-
-[[tool.cibuildwheel.overrides]]
-select = "cp3[67]*-macosx_x86_64"
-inherit.environment="append"
-environment = { SYSTEM_VERSION_COMPAT="0" }
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,11 @@ inherit.before-all="append"
 # need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
 before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
+[[tool.cibuildwheel.overrides]]
+select = "cp3[67]*-macosx_x86_64"
+inherit.environment="append"
+environment = { SYSTEM_VERSION_COMPAT="0" }
+
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths
 before-all = "nuget install gsl-msvc14-x64 -Version 2.3.0.2779"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,22 +63,22 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", MACOSX_DEPLOYMENT_TARGET="12" } # 12 / Monterey the minimum version of gsl supported by 'brew'
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_x86_64"
+inherit.environment="append"
+environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # 12 / Monterey the minimum version of gsl supported by 'brew'
 inherit.before-all="append"
 before-all = "brew install gsl"
-
-# [[tool.cibuildwheel.overrides]]
-# select = "*-macosx_x86_64"
-# inherit.environment="append"
-# inherit.before-all="append"
 # # install the catalina version of `gsl` to match
 # before-all = "brew fetch --force --bottle-tag=catalina gsl; brew reinstall $(brew --cache --bottle-tag=catalina gsl)"
 
-# [[tool.cibuildwheel.overrides]]
-# select = "*-macosx_arm64"
-# inherit.before-all="append"
-# # need to force the Big Sur (MacOS 11.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
-#before-all = "brew fetch --force --bottle-tag=arm64_big_sur gsl; brew reinstall $(brew --cache --bottle-tag=arm64_big_sur gsl)"
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+inherit.before-all="append"
+# need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
+before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,15 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib"}
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
+inherit.environment="append"
+environment = { MACOSX_DEPLOYMENT_TARGET="10.9" } # target 10.9 for brew rebuild
 inherit.before-all="append"
 before-all = "brew install --build-from-source gsl"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
+inherit.environment="append"
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0 for brew rebuild
 inherit.before-all="append"
 # need to force the Monterey (MacOS 12.0) version of `gsl` to match the wheel tag, otherwise it will attempt to install MacOS 14 version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ environment = { PIP_ONLY_BINARY=":all:" }
 
 [[tool.cibuildwheel.overrides]]
 # for latest CPython use newer manylinux image
-select = "cp312-*linux*"
+select = "cp-*linux*"
 manylinux-x86_64-image = "manylinux_2_28"
 
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
With the latest release of `gsl` of 2.8 on brew for MacOS, support for binary releases of `gsl` for versions of MacOS < 12 was dropped. This means that all CI builds currently fail on all MacOS systems.

In order to continue to support a minimum of 10.15 (Catalina) and later on x86, or 11.0 (Big Sur) and later on arm64, we would need to build `gsl` during the cibuildwheel process.  This would create a lot of maintenance overhead, and since Apple was EOLed Monterey and earlier, this PR creates wheels that will only install on MacOS 12 (Monterey) and later versions.

@sjmack : are you OK with making our minimum MacOS version be MacOS 12.0 (aka "Monterey")?