### PR TITLE
update x86 runner to `macos-13`, pin `swig` version

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -133,14 +133,14 @@ jobs:
         run: |
           echo "CI_ONLY" $CI_ONLY
           if [ "$CI_ONLY" == "true" ]; then
-            MATRIX="[{'only':'cp313-manylinux_x86_64','os':'ubuntu-20.04'},{'only':'cp313-win_amd64','os':'windows-2019'}, {'only':'cp313-macosx_x86_64','os':'macos-12'}, {'only':'cp313-macosx_arm64','os':'macos-14'}]"
+            MATRIX="[{'only':'cp313-manylinux_x86_64','os':'ubuntu-20.04'},{'only':'cp313-win_amd64','os':'windows-2019'}, {'only':'cp313-macosx_x86_64','os':'macos-13'}, {'only':'cp313-macosx_arm64','os':'macos-14'}]"
           else
             MATRIX=$(
               {
               cibuildwheel --print-build-identifiers --platform linux \
               | jq -nRc '{"only": inputs, "os": "ubuntu-20.04"}' \
               && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 \
-              | jq -nRc '{"only": inputs, "os": "macos-12"}' \
+              | jq -nRc '{"only": inputs, "os": "macos-13"}' \
               && cibuildwheel --print-build-identifiers --platform macos --archs arm64 \
               | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,11 @@ before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
+#before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
+before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,10 @@ musllinux-x86_64-image="musllinux_1_1"
 
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
-before-all = ["brew install swig@4.2.1 oras",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"] 
+before-all = ["brew install oras",
+              "oras pull ghcr.io/homebrew/core/swig:4.2.1",
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1",
+	      "brew install ./swig--4.2.1.monterey.bottle.tar.gz"] 
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15/Catalina
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target 10.15/Catalina
 inherit.before-all="append"
 # install the catalina version of `gsl` to match
 before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,11 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib",
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # target 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
+#before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
+before-all = "brew fetch --force --bottle-tag=monterey gsl; brew reinstall $(brew --cache --bottle-tag=monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ musllinux-x86_64-image="musllinux_1_1"
 
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
+# and archived 4.2.1 bottles of `swig` (swig 4.3.0 creates extensions that segfault)
 before-all = ["brew install oras",
               "oras pull ghcr.io/homebrew/core/swig:4.2.1",
 	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"] 
@@ -68,22 +69,20 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib",
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15/Catalina
 inherit.before-all="append"
-# install the Big Sur version of `gsl` to match
+# install `swig` and the Catalina version of `gsl` to match
 before-all = ["brew install ./swig--4.2.1.monterey.bottle.tar.gz",
 	   "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"]
-#before-all = "brew fetch --force --bottle-tag=monterey gsl; brew reinstall $(brew --cache --bottle-tag=monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
-inherit.before-all="append"
-# install the Big Sur version of `gsl` to match
+inherit.before-all="append"			
+# install `swig` and the Big Sur version of `gsl` to match
 before-all = ["brew install ./swig--4.2.1.arm64_ventura.bottle.tar.gz",
 	   "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
-#before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target 10.15/Catalina
 inherit.before-all="append"
 # install the catalina version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
+before-all = "brew install ./gsl--2.7.1.big_sur.bottle.tar.gz"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,18 +67,18 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target 10.15/Catalina
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target 11.0/Big Sur
 inherit.before-all="append"
-# install the catalina version of `gsl` to match
+# install the Big Sur version of `gsl` to match
 before-all = "brew install ./gsl--2.7.1.big_sur.bottle.tar.gz"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
+before-all = "brew install ./gsl--2.7.1.arm64_monterey.bottle.tar.gz"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,7 @@ musllinux-x86_64-image="musllinux_1_1"
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install oras",
               "oras pull ghcr.io/homebrew/core/swig:4.2.1",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1",
-	      "brew install ./swig--4.2.1.monterey.bottle.tar.gz"] 
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"] 
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [
@@ -69,20 +68,22 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib",
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # target 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-#before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
-before-all = "brew fetch --force --bottle-tag=monterey gsl; brew reinstall $(brew --cache --bottle-tag=monterey gsl)"
+before-all = ["brew install ./swig--4.2.1.monterey.bottle.tar.gz",
+	   "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"]
+#before-all = "brew fetch --force --bottle-tag=monterey gsl; brew reinstall $(brew --cache --bottle-tag=monterey gsl)"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # target for 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-#before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
-before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
+before-all = ["brew install ./swig--4.2.1.arm64_ventura.bottle.tar.gz",
+	   "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
+#before-all = "brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib" }
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", PYTHONFAULTHANDLER="1" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,18 +67,18 @@ environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib",
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.big_sur.bottle.tar.gz"
+before-all = "brew install ./gsl--2.7.1.catalina.bottle.tar.gz"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="13.0" } # target for 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.arm64_ventura.bottle.tar.gz"
+before-all = "brew install ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ musllinux-x86_64-image="musllinux_1_1"
 
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
-before-all = ["brew install swig oras",
+before-all = ["brew install swig@4.2.1 oras",
 	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"] 
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,10 @@ before-all = "brew install ./gsl--2.7.1.big_sur.bottle.tar.gz"
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment="append"
-environment = { MACOSX_DEPLOYMENT_TARGET="12.0" } # target for 11.0/Big Sur
+environment = { MACOSX_DEPLOYMENT_TARGET="13.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = "brew install ./gsl--2.7.1.arm64_monterey.bottle.tar.gz"
+before-all = "brew install ./gsl--2.7.1.arm64_ventura.bottle.tar.gz"
 
 [tool.cibuildwheel.windows]
 # use nuget to install gsl on Windows, and manually supply paths

--- a/tests/test_gthwe.py
+++ b/tests/test_gthwe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import base
 import sys
-#from PyPop import _Gthwe
+from PyPop import _Gthwe
 import pytest
 
 @pytest.mark.skip(reason="test is currently incomplete and doesn't run on all platforms")

--- a/tests/test_gthwe.py
+++ b/tests/test_gthwe.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import base
 import sys
-from PyPop import _Gthwe
+#from PyPop import _Gthwe
 import pytest
 
 @pytest.mark.skip(reason="test is currently incomplete and doesn't run on all platforms")


### PR DESCRIPTION
Some changes in the default runner packages, notably `swig` version bump from 4.2.1 to 4.3.0 caused builds to fail.