### PR TITLE
Update Windows image for CI: `windows-2019` -> `windows-2022`

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -160,7 +160,7 @@ jobs:
         run: |
           echo "CI_ONLY" $CI_ONLY
           if [ "$CI_ONLY" == "true" ]; then
-            MATRIX="[{'only':'cp313-manylinux_x86_64','os':'ubuntu-22.04'},{'only':'cp313-manylinux_aarch64','os':'ubuntu-22.04-arm'},{'only':'cp313-musllinux_x86_64','os':'ubuntu-22.04'},{'only':'cp313-musllinux_aarch64','os':'ubuntu-22.04-arm'},{'only':'cp313-win_amd64','os':'windows-2019'},{'only':'cp313-win_arm64','os':'windows-2019'},{'only':'cp313-macosx_x86_64','os':'macos-13'}, {'only':'cp313-macosx_arm64','os':'macos-14'}]"
+            MATRIX="[{'only':'cp313-manylinux_x86_64','os':'ubuntu-22.04'},{'only':'cp313-manylinux_aarch64','os':'ubuntu-22.04-arm'},{'only':'cp313-musllinux_x86_64','os':'ubuntu-22.04'},{'only':'cp313-musllinux_aarch64','os':'ubuntu-22.04-arm'},{'only':'cp313-win_amd64','os':'windows-2022'},{'only':'cp313-win_arm64','os':'windows-2022'},{'only':'cp313-macosx_x86_64','os':'macos-13'}, {'only':'cp313-macosx_arm64','os':'macos-14'}]"
           else
             MATRIX=$(
               {
@@ -173,7 +173,7 @@ jobs:
               && cibuildwheel --print-build-identifiers --platform macos --archs arm64 \
               | jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows \
-              | jq -nRc '{"only": inputs, "os": "windows-2019"}'
+              | jq -nRc '{"only": inputs, "os": "windows-2022"}'
             } | jq -sc
             )
           fi

--- a/tests/test_USAFEL.py
+++ b/tests/test_USAFEL.py
@@ -10,7 +10,6 @@ from base import (
     in_temp_dir,  # noqa: F401
     run_pypop_process,
     skip_musllinux_x86_64,
-    xfail_windows,
 )
 
 
@@ -97,9 +96,6 @@ def test_USAFEL_slatkin_guothompson_emhaplofreq():
     assert filecmp_ignore_newlines(out_filename, gold_out_filename)
 
 
-# FIXME: error in one-line of 2-locus-haplo.tsv on Windows
-# ld.d is 0.01563 rather than 0.01562
-@xfail_windows
 @skip_musllinux_x86_64
 def test_USAFEL_slatkin_guothompson_emhaplofreq_with_permu_tsv():
     exit_code = run_pypop_process(


### PR DESCRIPTION
`windows-2019` image is now deprecated, see: https://github.com/actions/runner-images/issues/12045