### PR TITLE
Update MacOS `cibuildwheel` config to handle `brew` changes

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -385,7 +385,7 @@ platforms, or no longer work, and need to be updated. Keeping around
 in case of either old platforms or if there is interest in reviving
 the feature(s) in question.
 
-## Installing `brew` bottles on MacOS
+### Installing `brew` bottles on MacOS
 
 Only needed when cross compiling on MacOS, but since we have native
 ARM64 runners, this `brew` workaround is `pyproject.toml` no longer

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -385,6 +385,24 @@ platforms, or no longer work, and need to be updated. Keeping around
 in case of either old platforms or if there is interest in reviving
 the feature(s) in question.
 
+## Installing `brew` bottles on MacOS
+
+Only needed when cross compiling on MacOS, but since we have native
+ARM64 runners, this `brew` workaround is `pyproject.toml` no longer
+needed. Maybe useful if needed in situations where cross-compilation
+is needed.
+
+```toml
+# re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
+# cross-compiling (https://stackoverflow.com/a/75488269)
+before-build = [
+  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
+  "if [[ $ARCHFLAGS == *arm64 ]]; then BOTTLE_TAG=arm64_big_sur gsl; else BOTTLE_TAG=x86_64_linux; fi",
+  "echo BOTTLE_TAG = $BOTTLE_TAG",
+]
+# force old bottle brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
+```
+
 ### Installing `swig` on certain Ubuntu releases
 
 (obsoleted by newer Ubuntu releases)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = ["brew install --quiet ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz 2> /dev/null"]
+before-all = ["ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install --quiet ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
 
 [tool.cibuildwheel.windows]
 archs = ["auto", "ARM64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ before-all = ["apk add gsl-dev"]
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install --quiet oras",
-              "oras copy ghcr.io/homebrew/core/gsl:2.7.1 --to-oci-layout ./gsl_oci",
-	      #"oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o .",
+              #"oras copy ghcr.io/homebrew/core/gsl:2.7.1 --to-oci-layout ./gsl_oci",
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o .",
 	    "ls -h"
 	   ]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
@@ -150,7 +150,7 @@ archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_*"
 inherit.environment="append"
-environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", PYTHONFAULTHANDLER="1", HOMEBREW_GREP_WARNINGS="-e 'is available and more recent than version' -e 'Cannot verify the integrity of'" }
+environment = { CPATH="/opt/homebrew/include", LIBRARY_PATH="/opt/homebrew/lib", PYTHONFAULTHANDLER="1", HOMEBREW_DEVELOPER="1", HOMEBREW_GREP_WARNINGS="-e 'is available and more recent than version' -e 'Cannot verify the integrity of'" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
@@ -167,12 +167,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
 before-all = [
-    "ls -l ./gsl_oci",
-    "find ./gsl_oci",
-    "ls -l ./gsl_oci/*/sha256-*big_sur*.tar.gz",
-    "file ./gsl_oci/*/sha256-*big_sur*.tar.gz",
-    "brew install --verbose --debug ./gsl_oci/blobs/sha256-*big_sur*.tar.gz"
-    #"ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
+    "ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
     ]
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,9 @@ before-all = ["apk add gsl-dev"]
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install --quiet oras",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject --artifact-type application/vnd.homebrew.bottle.tar+gzip -o ."]
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o .",
+	    "ls -h"
+	   ]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,10 +133,7 @@ before-all = ["apk add gsl-dev"]
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install --quiet oras",
-              #"oras copy ghcr.io/homebrew/core/gsl:2.7.1 --to-oci-layout ./gsl_oci",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o .",
-	    "ls -h"
-	   ]
+	     "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o ."]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [
@@ -166,9 +163,7 @@ inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = [
-    "ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
-    ]
+before-all = ["brew install --quiet ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
 
 [tool.cibuildwheel.windows]
 archs = ["auto", "ARM64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,8 @@ environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
 before-all = [
-    "ls -l ./gsl_oci/",
+    "ls -l ./gsl_oci",
+    "find ./gsl_oci",
     "ls -l ./gsl_oci/*/sha256-*big_sur*.tar.gz",
     "file ./gsl_oci/*/sha256-*big_sur*.tar.gz",
     "brew install --verbose --debug ./gsl_oci/blobs/sha256-*big_sur*.tar.gz"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ before-all = ["apk add gsl-dev"]
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install --quiet oras",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1"]
+	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject --artifact-type application/vnd.homebrew.bottle.tar+gzip -o ."]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
 # cross-compiling (https://stackoverflow.com/a/75488269)
 # before-build = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,15 +133,7 @@ before-all = ["apk add gsl-dev"]
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install --quiet oras",
-	     "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o ."]
-# re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
-# cross-compiling (https://stackoverflow.com/a/75488269)
-# before-build = [
-#  "echo ARCHFLAGS = $ARCHFLAGS", # gets the arch at build-time
-#  "if [[ $ARCHFLAGS == *arm64 ]]; then BOTTLE_TAG=arm64_big_sur gsl; else BOTTLE_TAG=x86_64_linux; fi",
-#  "echo BOTTLE_TAG = $BOTTLE_TAG",
-#]
-# force old bottle brew fetch --force --bottle-tag=arm64_monterey gsl; brew reinstall $(brew --cache --bottle-tag=arm64_monterey gsl)"
+	     "oras pull ghcr.io/homebrew/core/gsl:2.7.1"]
 archs = ["arm64", "x86_64"]  # don't enable "universal2" binary
 
 [[tool.cibuildwheel.overrides]]
@@ -155,7 +147,7 @@ inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="10.15" } # target 10.15/Catalina
 inherit.before-all="append"
 # install the Catalina version of `gsl` to match
-before-all = ["brew install --quiet ./gsl--2.7.1.catalina.bottle.tar.gz 2> /dev/null"]
+before-all = ["brew install --quiet ./gsl--2.7.1.catalina.bottle.tar.gz"]
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,8 @@ before-all = ["apk add gsl-dev"]
 [tool.cibuildwheel.macos]
 # use oras to get archived 2.7.1 bottles of `gsl` that has 10.15 (on x86) / 11.0 (on arm64) builds
 before-all = ["brew install --quiet oras",
-	      "oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o .",
+              "oras copy ghcr.io/homebrew/core/gsl:2.7.1 --to-oci-layout ./gsl_oci",
+	      #"oras pull ghcr.io/homebrew/core/gsl:2.7.1 --include-subject -o .",
 	    "ls -h"
 	   ]
 # re-enable if we need to  do a per-build 'gsl' installation to force correct architecture when
@@ -165,7 +166,13 @@ inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = ["ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
+before-all = [
+  # repeat the same commands for arm64, just in case cibuildwheel overrides per-arch
+    "ls -l ./gsl_oci/blobs/sha256-*big_sur*.tar.gz",
+    "file ./gsl_oci/blobs/sha256-*big_sur*.tar.gz",
+    "brew install --verbose --debug ./gsl_oci/blobs/sha256-*big_sur*.tar.gz"
+    #"ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
+    ]
 
 [tool.cibuildwheel.windows]
 archs = ["auto", "ARM64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,9 +167,9 @@ environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
 before-all = [
-  # repeat the same commands for arm64, just in case cibuildwheel overrides per-arch
-    "ls -l ./gsl_oci/blobs/sha256-*big_sur*.tar.gz",
-    "file ./gsl_oci/blobs/sha256-*big_sur*.tar.gz",
+    "ls -l ./gsl_oci/",
+    "ls -l ./gsl_oci/*/sha256-*big_sur*.tar.gz",
+    "file ./gsl_oci/*/sha256-*big_sur*.tar.gz",
     "brew install --verbose --debug ./gsl_oci/blobs/sha256-*big_sur*.tar.gz"
     #"ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ inherit.environment="append"
 environment = { MACOSX_DEPLOYMENT_TARGET="11.0" } # target for 11.0/Big Sur
 inherit.before-all="append"
 # install the Big Sur version of `gsl` to match
-before-all = ["ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install --quiet ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
+before-all = ["ls -l ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "file ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz", "brew install  --verbose --debug ./gsl--2.7.1.arm64_big_sur.bottle.tar.gz"]
 
 [tool.cibuildwheel.windows]
 archs = ["auto", "ARM64"]


### PR DESCRIPTION
GitHub updated `brew` from 4.6.3 to 4.6.6, which disables installing bottles from tarballs, by default (https://github.com/Homebrew/brew/pull/20414), breaking the build. This re-enables installation by setting `HOMEBREW_DEVELOPER=1`