### PR TITLE
Change  `--filename` behavior, all filenames are resolved relative to the supplied filename + enable 3.14

### DIFF
--- a/.github/scripts/gen-wheel-matrix.sh
+++ b/.github/scripts/gen-wheel-matrix.sh
@@ -42,7 +42,7 @@ if [[ "${CI_ONLY:-false}" == "true" ]]; then
             {"only":"cp313-win_arm64","os":"windows-2022","cibw_version": $ver},
             {"only":"cp313-macosx_x86_64","os":"macos-13","cibw_version": $ver},
             {"only":"cp313-macosx_arm64","os":"macos-14","cibw_version": $ver},
-            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver},
+            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver}
           ]
         ')
         echo "include=$FIXED_CI_MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/gen-wheel-matrix.sh
+++ b/.github/scripts/gen-wheel-matrix.sh
@@ -41,7 +41,8 @@ if [[ "${CI_ONLY:-false}" == "true" ]]; then
             {"only":"cp313-win_amd64","os":"windows-2022","cibw_version": $ver},
             {"only":"cp313-win_arm64","os":"windows-2022","cibw_version": $ver},
             {"only":"cp313-macosx_x86_64","os":"macos-13","cibw_version": $ver},
-            {"only":"cp313-macosx_arm64","os":"macos-14","cibw_version": $ver}
+            {"only":"cp313-macosx_arm64","os":"macos-14","cibw_version": $ver},
+            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver},
           ]
         ')
         echo "include=$FIXED_CI_MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/gen-wheel-matrix.sh
+++ b/.github/scripts/gen-wheel-matrix.sh
@@ -42,7 +42,8 @@ if [[ "${CI_ONLY:-false}" == "true" ]]; then
             {"only":"cp313-win_arm64","os":"windows-2022","cibw_version": $ver},
             {"only":"cp313-macosx_x86_64","os":"macos-13","cibw_version": $ver},
             {"only":"cp313-macosx_arm64","os":"macos-14","cibw_version": $ver},
-            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver}
+            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver},
+            {"only":"cp314t-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver}
           ]
         ')
         echo "include=$FIXED_CI_MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/gen-wheel-matrix.sh
+++ b/.github/scripts/gen-wheel-matrix.sh
@@ -42,8 +42,7 @@ if [[ "${CI_ONLY:-false}" == "true" ]]; then
             {"only":"cp313-win_arm64","os":"windows-2022","cibw_version": $ver},
             {"only":"cp313-macosx_x86_64","os":"macos-13","cibw_version": $ver},
             {"only":"cp313-macosx_arm64","os":"macos-14","cibw_version": $ver},
-            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver},
-            {"only":"cp314t-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver}
+            {"only":"cp314-manylinux_x86_64","os":"ubuntu-22.04","cibw_version": $ver}
           ]
         ')
         echo "include=$FIXED_CI_MATRIX" >> "$GITHUB_OUTPUT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ skip = ["*-win32", "*_i686",  # skip 32-bit builds
 	"pp*_aarch64 ",       # no numpy wheels for aarch64 on PyPy
 	"pp311-*",            # no numpy wheels for PyPy 3.11
     "cp36-musllinux_*", "cp37-musllinux_*", "cp38-musllinux_*", # older musllinux missing numpy wheels
-    "cp314*"]
+    "cp314t*"]
 test-skip = ["*-win_arm64", "cp38-macosx_arm64"]
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests ${PYTEST_OPTIONS}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,8 @@ skip = ["*-win32", "*_i686",  # skip 32-bit builds
      "pp37-*",             # skip certain PyPy configurations
      "pp*_aarch64 ",       # no numpy wheels for aarch64 on PyPy
      "pp311-*",            # no numpy wheels for PyPy 3.11
-     "cp36-musllinux_*", "cp37-musllinux_*", "cp38-musllinux_*" # older musllinux missing numpy wheels
+     "cp36-musllinux_*", "cp37-musllinux_*", "cp38-musllinux_*", # older musllinux missing numpy wheels
+     "cp314t*"             # lxml not yet built
      ]
 test-skip = ["*-win_arm64", "cp38-macosx_arm64"]
 test-extras = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,11 @@ testpaths = [
 [tool.cibuildwheel]
 enable = ["pypy"]             # explicitly enable, this will be required for cibuildwheel >= 3
 skip = ["*-win32", "*_i686",  # skip 32-bit builds
-        "pp37-*",             # skip certain PyPy configurations
-	"pp*_aarch64 ",       # no numpy wheels for aarch64 on PyPy
-	"pp311-*",            # no numpy wheels for PyPy 3.11
-    "cp36-musllinux_*", "cp37-musllinux_*", "cp38-musllinux_*", # older musllinux missing numpy wheels
-    "cp314t*"]
+     "pp37-*",             # skip certain PyPy configurations
+     "pp*_aarch64 ",       # no numpy wheels for aarch64 on PyPy
+     "pp311-*",            # no numpy wheels for PyPy 3.11
+     "cp36-musllinux_*", "cp37-musllinux_*", "cp38-musllinux_*" # older musllinux missing numpy wheels
+     ]
 test-skip = ["*-win_arm64", "cp38-macosx_arm64"]
 test-extras = ["test"]
 test-command = "pytest -v {package}/tests ${PYTEST_OPTIONS}"

--- a/src/PyPop/CommandLineInterface.py
+++ b/src/PyPop/CommandLineInterface.py
@@ -34,7 +34,6 @@ from argparse import (
     Action,
     ArgumentDefaultsHelpFormatter,
     ArgumentParser,
-    FileType,
     RawDescriptionHelpFormatter,
 )
 from pathlib import Path
@@ -239,7 +238,6 @@ current directory""",
         "-f",
         "--filelist",
         help="file containing list of files (one per line) to process. files are resolved relative to FILELIST, unless absolute. mutually exclusive with supplying POPFILEs)",
-        type=FileType("r"),
         default=None,
     )
     add_input(

--- a/src/PyPop/CommandLineInterface.py
+++ b/src/PyPop/CommandLineInterface.py
@@ -238,7 +238,7 @@ current directory""",
     add_input(
         "-f",
         "--filelist",
-        help="file containing list of files (one per line) to process\n(mutually exclusive with supplying POPFILEs)",
+        help="file containing list of files (one per line) to process. files are resolved relative to FILELIST, unless absolute. mutually exclusive with supplying POPFILEs)",
         type=FileType("r"),
         default=None,
     )

--- a/src/PyPop/pypop.py
+++ b/src/PyPop/pypop.py
@@ -241,13 +241,25 @@ return for each prompt.""")
         print(f"PyPop is processing {fileNames[0]} ...")
 
     else:
-        # non-interactive mode: run in 'batch' mode
+        # non-interactive mode: run in 'batch'xb mode
 
         if fileList:
             # if we are providing the filelist
             # use list from file as list to check
             # li = [f.strip('\n') for f in open(fileList).readlines()]
-            li = [f.strip("\n") for f in fileList.readlines()]
+
+            base_dir = (
+                Path(fileList.name).resolve().parent
+            )  # interpret paths relative to the fileList location
+            li = []
+            for line in fileList:
+                entry = line.strip()
+                if not entry:
+                    continue
+                p = Path(entry)
+                li.append(p if p.is_absolute() else (base_dir / p).resolve())
+
+            # li = [f.strip("\n") for f in fileList.readlines()]
             fileList.close()  # make sure we close it
         elif popFilenames:
             # check number of arguments, must be at least one, but can be more
@@ -264,7 +276,7 @@ return for each prompt.""")
         # arguments
         for fileName in li:
             # globbedFiles = glob_with_pathlib(fileName)
-            globbedFiles = glob(fileName)  # noqa: PTH207
+            globbedFiles = glob(str(fileName))  # noqa: PTH207
             if len(globbedFiles) == 0:
                 # if no files were found for that glob, please exit and warn
                 # the user

--- a/src/PyPop/pypop.py
+++ b/src/PyPop/pypop.py
@@ -246,21 +246,19 @@ return for each prompt.""")
         if fileList:
             # if we are providing the filelist
             # use list from file as list to check
-            # li = [f.strip('\n') for f in open(fileList).readlines()]
 
-            base_dir = (
-                Path(fileList.name).resolve().parent
-            )  # interpret paths relative to the fileList location
-            li = []
-            for line in fileList:
-                entry = line.strip()
-                if not entry:
-                    continue
-                p = Path(entry)
-                li.append(p if p.is_absolute() else (base_dir / p).resolve())
+            with open(fileList) as fileListHandle:
+                base_dir = (
+                    Path(fileListHandle.name).resolve().parent
+                )  # interpret paths relative to the fileListHandle location
+                li = []
+                for line in fileListHandle:
+                    entry = line.strip()
+                    if not entry:
+                        continue
+                    p = Path(entry)
+                    li.append(p if p.is_absolute() else (base_dir / p).resolve())
 
-            # li = [f.strip("\n") for f in fileList.readlines()]
-            fileList.close()  # make sure we close it
         elif popFilenames:
             # check number of arguments, must be at least one, but can be more
             # use args as list to check

--- a/tests/base.py
+++ b/tests/base.py
@@ -235,13 +235,24 @@ def run_script_process_entry_point(script_name, args):
     return 1 if ret_val else 0
 
 
-def run_pypop_process(inifile, popfile, args=None):
+def run_pypop_process(inifile, popfile=None, *, poplistfile=None, args=None):
     # convert relative data files to absolute
     if args is None:
         args = []
+
+    if popfile and poplistfile:
+        sys.exit("Cannot specify both popfile and poplistfile")
+
     inifile = abspath_test_data(inifile)
-    popfile = abspath_test_data(popfile)
-    pypop_args = ["-m", *args, "-c", inifile, popfile]
+    if popfile:
+        popfile = abspath_test_data(popfile)
+        pypop_args = ["-m", *args, "-c", inifile, popfile]
+    elif poplistfile:
+        poplistfile = abspath_test_data(poplistfile)
+        pypop_args = ["-m", *args, "--filelist", poplistfile, "-c", inifile]
+    else:
+        sys.exit("need to include either popfile or poplistfile")
+
     return run_script_process_entry_point("pypop", pypop_args)
 
 

--- a/tests/data/Test_Allele_Filelist.txt
+++ b/tests/data/Test_Allele_Filelist.txt
@@ -1,0 +1,2 @@
+./Test_Allele_Colon_Emhaplofreq.pop
+./Test_Allele_Colon_HardyWeinberg.pop

--- a/tests/test_Multiple_Files.py
+++ b/tests/test_Multiple_Files.py
@@ -38,7 +38,9 @@ def test_Multiple_Files_Absolute():
     ]
 
     # create a temporary filelist in the current working directory
-    with tempfile.NamedTemporaryFile("w", dir=".", delete=True) as tf:
+    # can't use context manager because we need to manually delete
+    tf = tempfile.NamedTemporaryFile("w", dir=".", suffix=".txt", delete=False)  # noqa: SIM115
+    try:
         for f in test_files:
             tf.write(str(f) + "\n")
         tf.flush()  # ensure content is written
@@ -48,7 +50,12 @@ def test_Multiple_Files_Absolute():
             abspath_test_data("tests/data/Test_Allele_Colon_HardyWeinberg.ini"),
             poplistfile=tf.name,
         )
-    assert exit_code == 0
+        assert exit_code == 0
+
+    finally:
+        Path(tf.name).unlink(missing_ok=True)  # clean up temp file
+
+    # check the generated files
     assert {
         p.name for p in Path().iterdir() if p.is_file()
     } == generated_filenames_common

--- a/tests/test_Multiple_Files.py
+++ b/tests/test_Multiple_Files.py
@@ -39,9 +39,9 @@ def test_Multiple_Files_Absolute():
 
     # create a temporary filelist in the current working directory
     # can't use context manager because we need to manually delete
-    tf = tempfile.NamedTemporaryFile("w", dir=".", suffix=".txt", delete=False)  # noqa: SIM115
-    tmpname = tf.name
-    try:
+    with tempfile.NamedTemporaryFile("w", dir=".", suffix=".txt", delete=False) as tf:
+        tmpname = tf.name
+
         for f in test_files:
             tf.write(str(f) + "\n")
         tf.flush()  # ensure content is written
@@ -53,8 +53,7 @@ def test_Multiple_Files_Absolute():
         )
         assert exit_code == 0
 
-    finally:
-        Path(tmpname).unlink(missing_ok=True)  # clean up temp file
+    Path(tmpname).unlink(missing_ok=True)  # clean up temp file, after run completed
 
     # check the generated files
     assert {

--- a/tests/test_Multiple_Files.py
+++ b/tests/test_Multiple_Files.py
@@ -1,0 +1,54 @@
+import tempfile
+from pathlib import Path
+
+from base import (
+    abspath_test_data,
+    in_temp_dir,  # noqa: F401
+    run_pypop_process,
+)
+
+generated_filenames_common = {
+    "Test_Allele_Colon_Emhaplofreq-out.txt",
+    "Test_Allele_Colon_Emhaplofreq-out.xml",
+    "Test_Allele_Colon_HardyWeinberg-out.txt",
+    "Test_Allele_Colon_HardyWeinberg-out.xml",
+}
+
+
+def test_Multiple_Files():
+    exit_code = run_pypop_process(
+        "./tests/data/Test_Allele_Colon_HardyWeinberg.ini",
+        poplistfile="./tests/data/Test_Allele_Filelist.txt",
+    )
+
+    # check exit code
+    assert exit_code == 0
+
+    # check that correct files are generated (don't check contents)
+    assert {
+        p.name for p in Path().iterdir() if p.is_file()
+    } == generated_filenames_common
+
+
+def test_Multiple_Files_Absolute():
+    # locate the test data files via abspath_test_data
+    test_files = [
+        abspath_test_data("tests/data/Test_Allele_Colon_Emhaplofreq.pop"),
+        abspath_test_data("tests/data/Test_Allele_Colon_HardyWeinberg.pop"),
+    ]
+
+    # create a temporary filelist in the current working directory
+    with tempfile.NamedTemporaryFile("w+", dir=".", delete=True) as tf:
+        for f in test_files:
+            tf.write(str(f) + "\n")
+        tf.flush()  # ensure content is written
+
+        # run pypop process with the absolute path filelist
+        exit_code = run_pypop_process(
+            abspath_test_data("tests/data/Test_Allele_Colon_HardyWeinberg.ini"),
+            poplistfile=tf.name,
+        )
+    assert exit_code == 0
+    assert {
+        p.name for p in Path().iterdir() if p.is_file()
+    } == generated_filenames_common

--- a/tests/test_Multiple_Files.py
+++ b/tests/test_Multiple_Files.py
@@ -38,7 +38,7 @@ def test_Multiple_Files_Absolute():
     ]
 
     # create a temporary filelist in the current working directory
-    with tempfile.NamedTemporaryFile("w+", dir=".", delete=True) as tf:
+    with tempfile.NamedTemporaryFile("w", dir=".", delete=True) as tf:
         for f in test_files:
             tf.write(str(f) + "\n")
         tf.flush()  # ensure content is written

--- a/tests/test_Multiple_Files.py
+++ b/tests/test_Multiple_Files.py
@@ -40,6 +40,7 @@ def test_Multiple_Files_Absolute():
     # create a temporary filelist in the current working directory
     # can't use context manager because we need to manually delete
     tf = tempfile.NamedTemporaryFile("w", dir=".", suffix=".txt", delete=False)  # noqa: SIM115
+    tmpname = tf.name
     try:
         for f in test_files:
             tf.write(str(f) + "\n")
@@ -48,12 +49,12 @@ def test_Multiple_Files_Absolute():
         # run pypop process with the absolute path filelist
         exit_code = run_pypop_process(
             abspath_test_data("tests/data/Test_Allele_Colon_HardyWeinberg.ini"),
-            poplistfile=tf.name,
+            poplistfile=tmpname,
         )
         assert exit_code == 0
 
     finally:
-        Path(tf.name).unlink(missing_ok=True)  # clean up temp file
+        Path(tmpname).unlink(missing_ok=True)  # clean up temp file
 
     # check the generated files
     assert {


### PR DESCRIPTION
* resolves all files within the file supplied to `--filename` relative to that FILENAME, i.e. if the file system looks like:

    ```
    data/
    data/popfilelist.txt
    data/file1.pop
    data/file2.pop
   ```
    and you run:
    ```
    pypop -c config.ini --filelist data/popfilelist.txt
    ```
   then contents of `popfilelist.txt` would be expected to be:
    ```
    file1.pop
    file2.pop
    ```
   in order to resolve the files.  Absolute path names don't need to be resolved

* Remove `FileType` from `---filelist`: deprecated in Python 3.14

* Reenable Python 3.14 builds
