### PR TITLE
update project configuration for current Scientific Python recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*~
+build/
+dist/
+.tox/
+.eggs/
+tests/__pycache__/
+wheelhouse/
+src/PyPop/__pycache__/
+src/PyPop/xslt/__pycache__/
+src/pypop.egg-info/
+src/pypopgen.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,3 +77,5 @@ exclude: 'tests/data/.*|data/.*|website/reference/.*|src/obsolete/.*|website/htm
 
 ci:
   autoupdate_commit_msg: 'chore: update pre-commit hooks'
+  autofix_commit_msg: 'style: pre-commit fixes'
+  autoupdate_schedule: weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,11 @@ repos:
     hooks:
       - id: pydoclint
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: "v1.29.0"
+    hooks:
+      - id: zizmor
+
 
 # FIXME: enable for static C analysis hooks
 #  - repo: https://github.com/ItsZcx/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,12 +59,6 @@ repos:
     hooks:
       - id: pydoclint
 
-  - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: "v1.29.0"
-    hooks:
-      - id: zizmor
-
-
 # FIXME: enable for static C analysis hooks
 #  - repo: https://github.com/ItsZcx/pre-commit-hooks
 #    rev: v1.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.16.3"
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--show-fixes"] # FIXME: add "--exit-zero" to list to commit to ignore ruff fixes
       - id: ruff-format
   - repo: https://github.com/hukkin/mdformat

--- a/noxfile.py
+++ b/noxfile.py
@@ -383,3 +383,7 @@ def publish_release(session):
             "gh", "release", "edit", f"{tag_name}", "--draft=false", external=True
         )
         session.log(f"Release: {tag_name} published.")
+
+
+if __name__ == "__main__":
+    nox.main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import nox
 from zoneinfo import ZoneInfo
 
-nox.options.sessions = ["precommit"]  # default session
+nox.needs_version = ">=2025.10.14"
+nox.options.default_venv_backend = "virtualenv"
+# nox.options.sessions = ["precommit"]  # default session
 
 # Eastern Time (handles DST automatically)
 ET = ZoneInfo("America/New_York")
@@ -53,7 +55,7 @@ def commit_with_retry(session, filename, message):
     return committed
 
 
-@nox.session
+@nox.session(default=True)
 def precommit(session):
     """Run all pre-commit hooks (code formatting, spell check, linting).
 
@@ -63,14 +65,14 @@ def precommit(session):
     session.run("pre-commit", "run", "--all-files")
 
 
-@nox.session
+@nox.session(default=False)
 def build(session):
     """Build the package (including binary extensions)."""
     session.install("build")
     session.run("python", "-m", "build")
 
 
-@nox.session
+@nox.session(default=False)
 def tests(session):
     """Run unit tests and doctests using pytest."""
     session.install(".[test]")  # now install assumes [test] includes pytest, etc.
@@ -79,7 +81,7 @@ def tests(session):
     )  # do docstring tests then unit tests
 
 
-@nox.session
+@nox.session(default=False)
 def docs(session):
     """Build HTML documentation with Sphinx."""
     output_dir = session.posargs[0] if len(session.posargs) == 1 else "_htmlbuild"
@@ -93,7 +95,7 @@ def docs(session):
     session.run("sphinx-build", "website", output_dir)
 
 
-@nox.session
+@nox.session(default=False)
 def docs_pdf(session):
     """Build PDF documentation with Sphinx. Requires LaTeX to already be installed."""
     output_dir = session.posargs[0] if len(session.posargs) == 1 else "_latexbuild"
@@ -108,7 +110,7 @@ def docs_pdf(session):
     session.run("make", "-C", output_dir)
 
 
-@nox.session
+@nox.session(default=False)
 def clean(session):
     # FIXME: very basic, needs work
     """Clean build artifacts."""
@@ -117,7 +119,7 @@ def clean(session):
     )
 
 
-@nox.session
+@nox.session(default=False)
 def sdist_test(session):
     """Build sdist, install with test extras, and run tests."""
     session.install("build")
@@ -143,7 +145,7 @@ def sdist_test(session):
     session.run("pytest", *session.posargs)
 
 
-@nox.session
+@nox.session(default=False)
 def update_news(session):
     """Update NEWS.md in local checkout from latest GitHub *draft* release notes (if not already present)."""
     session.log("Running update NEWS.md from latest release draft...")
@@ -210,7 +212,7 @@ def update_news(session):
     return "NEWS.md"
 
 
-@nox.session
+@nox.session(default=False)
 def push_news(session):
     """Commit and push local changes to NEWS.md back to repo."""
     news_filename = "NEWS.md"
@@ -236,7 +238,7 @@ def push_news(session):
             session.warn("no changes were committed, skipping git push...")
 
 
-@nox.session
+@nox.session(default=False)
 def bump_release_date(session):
     """Bump release date in draft release to today."""
     session.log("Fetching draft releases...")
@@ -307,7 +309,7 @@ def bump_release_date(session):
     return tag_name
 
 
-@nox.session
+@nox.session(default=False)
 def prepare_release(session):
     """Prepare latest release draft with correct tag, target, and NEWS.md update."""
     # Confirm branch
@@ -363,7 +365,7 @@ def prepare_release(session):
     return tag_name
 
 
-@nox.session
+@nox.session(default=False)
 def publish_release(session):
     """Finalize publishing the release after preparing it."""
     tag_name = prepare_release(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """nox commands."""
 
 import json
@@ -11,7 +12,6 @@ from zoneinfo import ZoneInfo
 
 nox.needs_version = ">=2025.10.14"
 nox.options.default_venv_backend = "virtualenv"
-# nox.options.sessions = ["precommit"]  # default session
 
 # Eastern Time (handles DST automatically)
 ET = ZoneInfo("America/New_York")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ xfail_strict = true
 # convert warnings to errors, except for ImportWarnings in numpy (needed for pp38)
 # FIXME: eventually we should be able to remove the numpy exception
 filterwarnings = ["error", "default::ImportWarning", "ignore:.*Arlequin.*deprecated.*"]
+log_level = "INFO"
 log_cli_level = "INFO"
 testpaths = [
   "website/docs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,7 @@ PC111 = "doesn't use blacken directly (uses ruff)"
 PC140 = "doesn't use typechecker"
 MY = "no typechecker"
 RTD = "doesn't use read the docs"
+SEC001 = "no enabled yet"
 
 [tool.pydoclint]
 style = "google"                        # Google style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,7 @@ PC140 = "doesn't use typechecker"
 MY = "no typechecker"
 RTD = "doesn't use read the docs"
 SEC001 = "no enabled yet"
+PP006 = "not using uv and using cibuildwheel"
 
 [tool.pydoclint]
 style = "google"                        # Google style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,6 +284,7 @@ MY = "no typechecker"
 RTD = "doesn't use read the docs"
 SEC001 = "no enabled yet"
 PP006 = "not using uv and using cibuildwheel"
+NOX201 = "does not use uv to bootstrap"
 
 [tool.pydoclint]
 style = "google"                        # Google style


### PR DESCRIPTION
Updates project tooling and configuration to address `reporeview` recommendations while preserving the existing development workflow.

- Configure pytest to capture INFO-level logs in addition to displaying them in the CLI.
- Update the Ruff pre-commit hook from `ruff` to `ruff-check`.
- Add explicit pre-commit.ci autofix and autoupdate settings.
- Add Nox minimum version and virtualenv backend configuration.
- Use explicit per-session defaults in the Nox configuration while keeping `precommit` as the only default session.
- Add a Python shebang and `__main__` entry point to allow `noxfile.py` to be run directly.
- Preserve the existing `test` package extra rather than introducing a duplicate dependency group solely for reporeview.